### PR TITLE
Standards Maintenance Issue #322: Updated x-fapi-auth-date non-normative example

### DIFF
--- a/slate/source/includes/standards/_headers.md
+++ b/slate/source/includes/standards/_headers.md
@@ -10,7 +10,7 @@ Supported HTTP headers, and their usage, for the standards are as laid out in th
 `x-v : 5`  
 `x-min-v : 3`  
 `x-fapi-interaction-id : 6ba7b814-9dad-11d1-80b4-00c04fd430c8`  
-`x-fapi-auth-date : Thu, 16 Jan 2020 16:50:15 GMT`
+`x-fapi-auth-date : Thu, 16 Jan 2020 16:50:15 GMT`  
 `x-fapi-customer-ip-address : 2001:0db8:85a3:0000:0000:8a2e:0370:7334`  
 `x-cds-client-headers : TW96aWxsYS81LjAgKFgxMTsgTGludXggeDg2XzY0KSBBcHBsZVdlYktpdC81MzcuMzYgKEtIVE1MLCBsaWtlIEdlY2tvKSBDaHJvbWUvNzkuMC4zOTQ1Ljg4IFNhZmFyaS81MzcuMzY=`  
 

--- a/slate/source/includes/standards/_headers.md
+++ b/slate/source/includes/standards/_headers.md
@@ -10,7 +10,7 @@ Supported HTTP headers, and their usage, for the standards are as laid out in th
 `x-v : 5`  
 `x-min-v : 3`  
 `x-fapi-interaction-id : 6ba7b814-9dad-11d1-80b4-00c04fd430c8`  
-`x-fapi-auth_date : 2020-01-16 16:50:15.507399`  
+`x-fapi-auth-date : Thu, 16 Jan 2020 16:50:15 GMT`
 `x-fapi-customer-ip-address : 2001:0db8:85a3:0000:0000:8a2e:0370:7334`  
 `x-cds-client-headers : TW96aWxsYS81LjAgKFgxMTsgTGludXggeDg2XzY0KSBBcHBsZVdlYktpdC81MzcuMzYgKEtIVE1MLCBsaWtlIEdlY2tvKSBDaHJvbWUvNzkuMC4zOTQ1Ljg4IFNhZmFyaS81MzcuMzY=`  
 


### PR DESCRIPTION
Corrects the header key and express the value as a HTTP-date as in section 7.1.1.1 of RFC7231