### PR TITLE
Standards Maintenance Issue #309

### DIFF
--- a/slate/source/includes/releasenotes/releasenotes.1.7.0.html.md
+++ b/slate/source/includes/releasenotes/releasenotes.1.7.0.html.md
@@ -24,7 +24,7 @@ This release pertains to the changes approved by the Data Standards Chair in [De
 
 |Change|Description|Link|
 |------|-----------|----|
-|  |  |
+| Fixed paymentsRemaining value in Scheduled Payment non-normative examples | Non-normative examples showed paymentsRemaining = 0 however paymentsRemaining is a PositiveInteger with a value of 1 or greater. | [Scheduled Payments APIs](../../#get-scheduled-payments-for-account) |
 
 ## Information Security Profile
 |Change|Description|Link|

--- a/swagger-gen/api/cds_full.json
+++ b/swagger-gen/api/cds_full.json
@@ -3727,7 +3727,7 @@
           "type": "integer",
           "description": "Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely",
           "x-cds-type": "PositiveInteger",
-          "minimum": "1"
+          "example": 1
         },
         "nonBusinessDayTreatment": {
           "type": "string",
@@ -3784,7 +3784,7 @@
           "type": "integer",
           "description": "Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely",
           "x-cds-type": "PositiveInteger",
-          "minimum": 1
+          "example": 1
         },
         "interval": {
           "type": "string",

--- a/swagger-gen/api/cds_full.json
+++ b/swagger-gen/api/cds_full.json
@@ -3726,7 +3726,8 @@
         "paymentsRemaining": {
           "type": "integer",
           "description": "Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely",
-          "x-cds-type": "PositiveInteger"
+          "x-cds-type": "PositiveInteger",
+          "minimum": "1"
         },
         "nonBusinessDayTreatment": {
           "type": "string",
@@ -3782,7 +3783,8 @@
         "paymentsRemaining": {
           "type": "integer",
           "description": "Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely",
-          "x-cds-type": "PositiveInteger"
+          "x-cds-type": "PositiveInteger",
+          "minimum": 1
         },
         "interval": {
           "type": "string",


### PR DESCRIPTION
Updated non-normative example for scheduled payment to display paymentsRemaining = 1 instead of 0 which is not an allowed value