### PR TITLE
poc secondary-dataholder-apis: 

### DIFF
--- a/slate/source/includes/_energy_apis_sdh.md.erb
+++ b/slate/source/includes/_energy_apis_sdh.md.erb
@@ -1,0 +1,13 @@
+
+# Energy Secondary DH APIs
+
+
+This specification defines the APIs for Data Holders exposing Energy Secondary Data Holder endpoints.
+
+
+<table>
+<tr><td><a href='./includes/swagger/cds_energy_sdh.json'>Energy Secondary Data Holder Swagger (JSON)</a></td></tr>
+<tr><td><a href='./includes/swagger/cds_energy_sdh.yaml'>Energy Secondary Data Holder Swagger (YAML)</a></td></tr>
+</table>
+
+<%= partial "includes/cds_energy_sdh.md" %>

--- a/slate/source/index.html.md
+++ b/slate/source/index.html.md
@@ -34,6 +34,7 @@ includes:
   - admin
   - separator
   - secondary_responsibility
+  - energy_apis_sdh
   - separator
   - known-issues
   - changelog

--- a/swagger-gen/api/cds_energy_sdh.json
+++ b/swagger-gen/api/cds_energy_sdh.json
@@ -1,0 +1,1774 @@
+{
+	"openapi": "3.0.3",
+	"info": {
+		"title": "CDR Energy Secondary Data Holder API",
+		"description": "Consumer Data Right end points and payloads for Secondary Data Holder for the Energy sector",
+		"version": "1.15.0"
+	},
+	"components": {
+		"schemas": {
+            "EnergyServicePointListResponse": {
+                "type": "object",
+                "required": [
+                    "data",
+                    "links",
+                    "meta"
+                ],
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "servicePoints"
+                        ],
+                        "properties": {
+                            "servicePoints": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/EnergyServicePoint"
+                                }
+                            }
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/LinksPaginated"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/MetaPaginated"
+                    }
+                }
+            },
+            "EnergyServicePointDetailResponse": {
+                "type": "object",
+                "required": [
+                    "data",
+                    "links",
+                    "meta"
+                ],
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/EnergyServicePointDetail"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/Meta"
+                    }
+                }
+            },
+            "EnergyUsageListResponse": {
+                "type": "object",
+                "required": [
+                    "data",
+                    "links",
+                    "meta"
+                ],
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "reads"
+                        ],
+                        "properties": {
+                            "reads": {
+                                "description": "Array of meter reads",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/EnergyUsageRead"
+                                }
+                            }
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/LinksPaginated"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/MetaPaginated"
+                    }
+                }
+            },
+            "EnergyDerListResponse": {
+                "type": "object",
+                "required": [
+                    "data",
+                    "links",
+                    "meta"
+                ],
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "derRecords"
+                        ],
+                        "properties": {
+                            "derRecords": {
+                                "description": "Array of meter reads",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/EnergyDerRecord"
+                                }
+                            }
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/LinksPaginated"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/MetaPaginated"
+                    }
+                }
+            },
+            "EnergyDerDetailResponse": {
+                "type": "object",
+                "required": [
+                    "data",
+                    "links",
+                    "meta"
+                ],
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/EnergyDerRecord"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/Meta"
+                    }
+                }
+            },
+            "ErrorListResponse": {
+                "type": "object",
+                "required": [
+                    "errors"
+                ],
+                "x-conditional": [ "meta" ],
+                "properties": {
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "code",
+                                "title",
+                                "detail"
+                            ],
+                            "properties": {
+                                "code": {
+                                    "type": "string",
+                                    "description": "The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN."
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "description": "A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code."
+                                },
+                                "detail": {
+                                    "type": "string",
+                                    "description": "A human-readable explanation specific to this occurrence of the problem."
+                                },
+                                "meta": {
+                                    "type" : "object",
+                                    "x-conditional" : [ "urn" ],
+                                    "description" : "Additional data for customised error codes",
+                                    "properties" : {
+                                       "urn": {
+                                          "type": "string",
+                                          "description": "The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code."
+                                       }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "EnergyServicePoint": {
+                "type": "object",
+                "required": [
+                    "servicePointId",
+                    "nationalMeteringId",
+                    "servicePointClassification",
+                    "servicePointStatus",
+                    "jurisdictionCode",
+                    "validFromDate",
+                    "lastUpdateDateTime"
+                ],
+                "properties": {
+                    "servicePointId": {
+                        "type": "string",
+                        "description": "The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO."
+                    },
+                    "nationalMeteringId": {
+                        "type": "string",
+                        "description": "The independent ID of the service point, known in the industry as the NMI"
+                    },
+                    "servicePointClassification": {
+                        "type": "string",
+                        "description": "The classification of the service point as defined in MSATS procedures",
+                        "enum": ["EXTERNAL_PROFILE",
+                            "GENERATOR",
+                            "LARGE",
+                            "SMALL",
+                            "WHOLESALE",
+                            "NON_CONTEST_UNMETERED_LOAD",
+                            "NON_REGISTERED_EMBEDDED_GENERATOR",
+                            "DISTRIBUTION_WHOLESALE"
+                        ]
+                    },
+                    "servicePointStatus": {
+                        "type": "string",
+                        "description": "Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul> ",
+                        "enum": ["ACTIVE",
+                            "DE_ENERGISED",
+                            "EXTINCT",
+                            "GREENFIELD",
+                            "OFF_MARKET"
+                        ]
+                    },
+                    "jurisdictionCode": {
+                        "type": "string",
+                        "description": "Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>",
+                        "enum": ["ALL",
+                            "ACT",
+                            "NEM",
+                            "NSW",
+                            "QLD",
+                            "SA",
+                            "TAS",
+                            "VIC"
+                        ]
+                    },
+                    "isGenerator": {
+                        "type": "boolean",
+                        "description": "This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer"
+                    },
+                    "validFromDate": {
+                        "type": "string",
+                        "x-cds-type": "DateString",
+                        "description": "The start date from which this service point first became valid"
+                    },
+                    "lastUpdateDateTime": {
+                        "type": "string",
+                        "x-cds-type": "DateTimeString",
+                        "description": "The date and time that the information for this service point was modified"
+                    },
+                    "consumerProfile": {
+                        "type": "object",
+                        "properties": {
+                            "classification": {
+                                "type": "string",
+                                "description": "A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments",
+                                "enum": ["BUSINESS",
+                                    "RESIDENTIAL"
+                                ]
+                            },
+                            "threshold": {
+                                "description": "A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>",
+                                "enum": ["LOW",
+                                    "MEDIUM",
+                                    "HIGH"
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "EnergyServicePointDetail": {
+                "required": [
+                    "servicePointId",
+                    "nationalMeteringId",
+                    "servicePointClassification",
+                    "servicePointStatus",
+                    "jurisdictionCode",
+                    "validFromDate",
+                    "lastUpdateDateTime",
+                    "distributionLossFactor",
+                    "relatedParticipants",
+                    "location",
+                    "meters"
+                ],
+                "properties": {
+                    "servicePointId": {
+                        "type": "string",
+                        "description": "The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO."
+                    },
+                    "nationalMeteringId": {
+                        "type": "string",
+                        "description": "The independent ID of the service point, known in the industry as the NMI"
+                    },
+                    "servicePointClassification": {
+                        "type": "string",
+                        "description": "The classification of the service point as defined in MSATS procedures",
+                        "enum": ["EXTERNAL_PROFILE",
+                            "GENERATOR",
+                            "LARGE",
+                            "SMALL",
+                            "WHOLESALE",
+                            "NON_CONTEST_UNMETERED_LOAD",
+                            "NON_REGISTERED_EMBEDDED_GENERATOR",
+                            "DISTRIBUTION_WHOLESALE"
+                        ]
+                    },
+                    "servicePointStatus": {
+                        "type": "string",
+                        "description": "Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul> ",
+                        "enum": ["ACTIVE",
+                            "DE_ENERGISED",
+                            "EXTINCT",
+                            "GREENFIELD",
+                            "OFF_MARKET"
+                        ]
+                    },
+                    "jurisdictionCode": {
+                        "type": "string",
+                        "description": "Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>",
+                        "enum": ["ALL",
+                            "ACT",
+                            "NEM",
+                            "NSW",
+                            "QLD",
+                            "SA",
+                            "TAS",
+                            "VIC"
+                        ]
+                    },
+                    "isGenerator": {
+                        "type": "boolean",
+                        "description": "This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer"
+                    },
+                    "validFromDate": {
+                        "type": "string",
+                        "x-cds-type": "DateString",
+                        "description": "The start date from which this service point first became valid"
+                    },
+                    "lastUpdateDateTime": {
+                        "type": "string",
+                        "x-cds-type": "DateTimeString",
+                        "description": "The date and time that the information for this service point was modified"
+                    },
+                    "consumerProfile": {
+                        "type": "object",
+                        "properties": {
+                            "classification": {
+                                "type": "string",
+                                "description": "A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments",
+                                "enum": ["BUSINESS",
+                                    "RESIDENTIAL"
+                                ]
+                            },
+                            "threshold": {
+                                "description": "A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>",
+                                "enum": ["LOW",
+                                    "MEDIUM",
+                                    "HIGH"
+                                ]
+                            }
+                        }
+                    },
+                    "distributionLossFactor": {
+                        "type": "object",
+                        "required": [
+                            "code",
+                            "description",
+                            "lossValue"
+                        ],
+                        "properties": {
+                            "code": {
+                                "type": "string",
+                                "description": "A code used to identify data loss factor for the service point values.  Refer to AEMO distribution loss factor documents for each financial year to interpret"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the data loss factor code and value"
+                            },
+                            "lossValue": {
+                                "type": "string",
+                                "description": "The value associated with the loss factor code"
+                            }
+                        }
+                    },
+                    "relatedParticipants": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["party", "role", "location"],
+                            "properties": {
+
+                                "party": {
+                                    "type": "string",
+                                    "description": "The name of the party/orginsation related to this service point"
+                                },
+                                "role": {
+                                    "type": "string",
+                                    "description": "The role performed by this participant in relation to the service point. Note the details of enumeration values below: <ul><li>**FRMP** - Financially Responsible Market Participant</li><li>**LNSP** - Local Network Service Provider or Embedded Network Manager for child connection points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary Service Provider and note that where it is not relevant for a NMI it will not be included</li></ul>",
+                                    "enum": ["FRMP",
+                                        "LNSP",
+                                        "DRSP"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "location": {
+                        "type": "object",
+                        "required": ["addressUType"],
+                        "x-conditional": [
+                            "simple",
+                            "paf"
+                        ],
+                        "properties": {
+                            "addressUType": {
+                                "type": "string",
+                                "description": "The type of address object present",
+                                "enum": ["simple",
+                                    "paf"
+                                ]
+                            },
+                            "simple": {
+                                "description": "The address of the service point.  Mandatory if addressUType is set to simple",
+                                "type": "object",
+                                "required": ["addressLine1", "city", "state"],
+                                "x-conditional": ["postcode"],
+                                "properties": {
+                                    "mailingName": {
+                                        "type": "string",
+                                        "description": "Name of the individual or business formatted for inclusion in an address used for physical mail"
+                                    },
+                                    "addressLine1": {
+                                        "type": "string",
+                                        "description": "First line of the standard address object"
+                                    },
+                                    "addressLine2": {
+                                        "type": "string",
+                                        "description": "Second line of the standard address object"
+                                    },
+                                    "addressLine3": {
+                                        "type": "string",
+                                        "description": "Third line of the standard address object"
+                                    },
+                                    "postcode": {
+                                        "type": "string",
+                                        "description": "Mandatory for Australian addresses"
+                                    },
+                                    "city": {
+                                        "type": "string",
+                                        "description": "Name of the city or locality"
+                                    },
+                                    "state": {
+                                        "type": "string",
+                                        "description": "Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT"
+                                    },
+                                    "country": {
+                                        "type": "string",
+                                        "description": "A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.",
+                                        "default": "AUS",
+                                        "x-cds-type": "ExternalRef"
+                                    }
+                                }
+                            },
+                            "paf": {
+                                "description": "The address of the service point.  Mandatory if addressUType is set to paf. Formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)",
+                                "type": "object",
+                                "required": ["localityName", "postcode", "state"],
+                                "properties": {
+                                    "dpid": {
+                                        "type": "string",
+                                        "description": "Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier"
+                                    },
+                                    "thoroughfareNumber1": {
+                                        "type": "integer",
+                                        "description": "Thoroughfare number for a property (first number in a property ranged address)",
+                                        "x-cds-type": "PositiveInteger"
+                                    },
+                                    "thoroughfareNumber1Suffix": {
+                                        "type": "string",
+                                        "description": "Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated"
+                                    },
+                                    "thoroughfareNumber2": {
+                                        "type": "integer",
+                                        "description": "Second thoroughfare number (only used if the property has a ranged address eg 23-25)",
+                                        "x-cds-type": "PositiveInteger"
+                                    },
+                                    "thoroughfareNumber2Suffix": {
+                                        "type": "string",
+                                        "description": "Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated"
+                                    },
+                                    "flatUnitType": {
+                                        "type": "string",
+                                        "description": "Type of flat or unit for the address"
+                                    },
+                                    "flatUnitNumber": {
+                                        "type": "string",
+                                        "description": "Unit number (including suffix, if applicable)"
+                                    },
+                                    "floorLevelType": {
+                                        "type": "string",
+                                        "description": "Type of floor or level for the address"
+                                    },
+                                    "floorLevelNumber": {
+                                        "type": "string",
+                                        "description": "Floor or level number (including alpha characters)"
+                                    },
+                                    "lotNumber": {
+                                        "type": "string",
+                                        "description": "Allotment number for the address"
+                                    },
+                                    "buildingName1": {
+                                        "type": "string",
+                                        "description": "Building/Property name 1"
+                                    },
+                                    "buildingName2": {
+                                        "type": "string",
+                                        "description": "Building/Property name 2"
+                                    },
+                                    "streetName": {
+                                        "type": "string",
+                                        "description": "The name of the street"
+                                    },
+                                    "streetType": {
+                                        "type": "string",
+                                        "description": "The street type. Valid enumeration defined by Australia Post PAF code file"
+                                    },
+                                    "streetSuffix": {
+                                        "type": "string",
+                                        "description": "The street type suffix. Valid enumeration defined by Australia Post PAF code file"
+                                    },
+                                    "postalDeliveryType": {
+                                        "type": "string",
+                                        "description": "Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file"
+                                    },
+                                    "postalDeliveryNumber": {
+                                        "type": "integer",
+                                        "description": "Postal delivery number if the address is a postal delivery type",
+                                        "x-cds-type": "PositiveInteger"
+                                    },
+                                    "postalDeliveryNumberPrefix": {
+                                        "type": "string",
+                                        "description": "Postal delivery number prefix related to the postal delivery number"
+                                    },
+                                    "postalDeliveryNumberSuffix": {
+                                        "type": "string",
+                                        "description": "Postal delivery number suffix related to the postal delivery number"
+                                    },
+                                    "localityName": {
+                                        "type": "string",
+                                        "description": "Full name of locality"
+                                    },
+                                    "postcode": {
+                                        "type": "string",
+                                        "description": "Postcode for the locality"
+                                    },
+                                    "state": {
+                                        "type": "string",
+                                        "description": "State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "meters": {
+                        "type": "object",
+                        "required": [
+                            "meterId",
+                            "specifications",
+                            "registers"
+                        ],
+                        "properties": {
+                            "meterId": {
+                                "type": "string",
+                                "description": "The meter ID uniquely identifies a meter for a given service point.  It is unique in the context of the service point.  It is not globally unique"
+                            },
+                            "specifications": {
+                                "type": "object",
+                                "description": "Technical characteristics of the meter",
+                                "required": [
+                                    "status",
+                                    "installationType"
+                                ],
+                                "properties": {
+                                    "status": {
+                                        "type": "string",
+                                        "description": "A code to denote the status of the meter. Note the details of enumeration values below: <ul><li>**CURRENT** -Applies when a meter is current and not disconnected</li><li>**DISCONNECTED** - Applies when a meter is present but has been remotely disconnected</li></ul>",
+                                        "enum": ["CURRENT",
+                                            "DISCONNECTED"
+                                        ]
+                                    },
+                                    "installationType": {
+                                        "type": "string",
+                                        "description": "The metering Installation type code indicates whether the metering installation has to be manually read. Note the details of enumeration values below: <ul><li>**BASIC** - Accumulation Meter – Type 6</li><li>**COMMS1** - Interval Meter with communications – Type 1</li><li>**COMMS2** - Interval Meter with communications – Type 2</li><li>**COMMS3** - Interval Meter with communications – Type 3</li><li>**COMMS4** - Interval Meter with communications – Type 4</li><li>**COMMS4C** - CT connected metering installation that meets the minimum services specifications</li><li>**COMMS4D** - Whole current metering installation that meets the minimum services specifications</li><li>**MRAM** - Small customer metering installation – Type 4A</li><li>**MRIM** - Manually Read Interval Meter – Type 5</li><li>**UMCP** - Unmetered Supply – Type 7</li><li>**VICAMI** - A relevant metering installation as defined in clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load - Introduced as part of Global Settlement</li></ul>",
+                                        "enum": ["BASIC",
+                                            "COMMS1",
+                                            "COMMS2",
+                                            "COMMS3",
+                                            "COMMS4",
+                                            "COMMS4C",
+                                            "COMMS4D",
+                                            "MRAM",
+                                            "MRIM",
+                                            "PROF",
+                                            "SAMPLE",
+                                            "UMCP",
+                                            "VICAMI",
+                                            "NCOLNUML"
+                                        ]
+                                    },
+                                    "manufacturer": {
+                                        "type": "string",
+                                        "description": "Free text field to identify the manufacturer of the installed meter"
+                                    },
+                                    "model": {
+                                        "type": "string",
+                                        "description": "Free text field to identify the meter manufacturer’s designation for the meter model"
+                                    },
+                                    "readType": {
+                                        "type": "string",
+                                        "description": "Code to denote the method and frequency of Meter Reading. The value is formatted as follows: <ul><li>First Character = Remote (R) or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 = Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional Fourth Character = to identify what interval length the meter is capable of reading. This includes five, 15 and 30 minute granularity as the following: A – 5 minute B – 15 minute C – 30 minute D – Cannot convert to 5 minute (i.e. due to metering installation de-energised) M - Manually Read Accumulation Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li> <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li> <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>"
+                                    },
+                                    "nextScheduledReadDate": {
+                                        "type": "string",
+                                        "x-cds-type": "DateString",
+                                        "description": "This date is the next scheduled meter read date (NSRD) if a manual Meter Reading is required"
+                                    }
+                                }
+                            },
+                            "registers": {
+                                "type": "object",
+                                "description": "Usage data registers available from the meter",
+                                "required": [
+                                    "registerId",
+                                    "registerSuffix",
+                                    "registerConsumptionType"
+                                ],
+                                "properties": {
+                                    "registerId": {
+                                        "type": "string",
+                                        "description": "Unique identifier of the register within this service point.  Is not globally unique"
+                                    },
+                                    "registerSuffix": {
+                                        "type": "string",
+                                        "description": "Register suffix of the meter register where the meter reads are obtained"
+                                    },
+                                    "averagedDailyLoad": {
+                                        "type": "number",
+                                        "description": "The energy delivered through a connection point or metering point over an extended period normalised to a 'per day' basis (kWh). This value is calculated annually."
+                                    },
+                                    "registerConsumptionType": {
+                                        "type": "string",
+                                        "description": "Indicates the consumption type of register",
+                                        "enum": ["INTERVAL",
+                                            "BASIC",
+                                            "PROFILE_DATA",
+                                            "ACTIVE_IMPORT",
+                                            "ACTIVE",
+                                            "REACTIVE_IMPORT",
+                                            "REACTIVE"
+                                        ]
+                                    },
+                                    "networkTariffCode": {
+                                        "type": "string",
+                                        "description": "The Network Tariff Code is a free text field containing a code supplied and published by the local network service provider"
+                                    },
+                                    "unitOfMeasure": {
+                                        "type": "string",
+                                        "description": "The unit of measure for data held in this register"
+                                    },
+                                    "timeOfDay": {
+                                        "type": "string",
+                                        "description": "Code to identify the time validity of register contents",
+                                        "enum": ["ALLDAY",
+                                            "INTERVAL",
+                                            "PEAK",
+                                            "BUSINESS",
+                                            "SHOULDER",
+                                            "EVENING",
+                                            "OFFPEAK",
+                                            "CONTROLLED",
+                                            "DEMAND"
+                                        ]
+                                    },
+                                    "multiplier": {
+                                        "type": "number",
+                                        "description": "Multiplier required to take a register value and turn it into a value representing billable energy"
+                                    },
+                                    "controlledLoad": {
+                                        "type": "boolean",
+                                        "description": "Indicates whether the energy recorded by this register is created under a Controlled Load regime. ControlledLoad field will have 'No' if register does not relate to a Controlled Load.  If the register relates to a Controlled Load, it should contain a description of the Controlled Load regime. ControlledLoad field will have 'No' if register does not relate to a Controlled Load, “Yes” if register relates to a Controlled Load If absent the status is unknown. "
+                                    },
+                                    "consumptionType": {
+                                        "type": "string",
+                                        "description": "Actual/Subtractive Indicator. Note the details of enumeration values below: <ul><li>**ACTUAL** implies volume of energy actually metered between two dates</li><li>**CUMULATIVE** indicates a meter reading for a specific date. A second Meter Reading is required to determine the consumption between those two Meter Reading dates</li></ul>",
+                                        "enum": ["ACTUAL",
+                                            "CUMULATIVE"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "EnergyUsageRead": {
+                "type": "object",
+                "required": [
+                    "servicePointId",
+                    "registerSuffix",
+                    "readStartDate",
+                    "readUType"
+                ],
+                "x-conditional": [
+                    "basicRead",
+                    "intervalRead"
+                ],
+                "properties": {
+                    "servicePointId": {
+                    "description": "The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.",
+                        "type": "string"
+                    },
+                    "registerId": {
+                        "description": "Register ID of the meter register where the meter reads are obtained",
+                        "type": "string"
+                    },
+                    "registerSuffix": {
+                        "description": "Register suffix of the meter register where the meter reads are obtained",
+                        "type": "string"
+                    },
+                    "meterID": {
+                        "description": "Meter id/serial number as it appears in customer’s bill. ID permanence rules do not apply.",
+                        "type": "string"
+                    },
+                    "controlledLoad": {
+                        "description": "Indicates whether the energy recorded by this register is created under a Controlled Load regime. ControlledLoad field will have 'No if register does not relate to a Controlled Load, “Yes” if register relates to a Controlled Load If absent the status is unknown. ",
+                        "type": "boolean"
+                    },
+                    "readStartDate": {
+                        "description": "Date time when the meter reads start",
+                        "type": "string",
+                        "x-cds-type": "DateString"
+                    },
+                    "readEndDate": {
+                        "description": "Date time when the meter reads end.  If absent then assumed to be equal to readStartDate.  In this case the entry represents data for a single date specified by readStartDate",
+                        "type": "string",
+                        "x-cds-type": "DateString"
+                    },
+                    "unitOfMeasure": {
+                        "description": "Unit of measure of the meter reads. Refer to Appendix B of <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF Specification NEM12 NEM13 v2.1</a> for a list of possible values",
+                        "type": "string"
+                    },
+                    "readUType": {
+                        "description": "Specify the type of the meter read data",
+                        "type": "string",
+                        "enum": [
+                            "basicRead",
+                            "intervalRead"
+                        ]
+                    },
+                    "basicRead": {
+                        "description": "Mandatory if readUType is set to basicRead",
+                        "type": "object",
+                        "required": [
+                            "value"
+                        ],
+                        "properties": {
+                            "quality": {
+                                "description": "The quality of the read taken.  If absent then assumed to be ACTUAL",
+                                "type": "string",
+                                "enum": [
+                                    "ACTUAL",
+                                    "SUBSTITUTE",
+                                    "FINAL_SUBSTITUTE"
+                                ],
+                                "default": "ACTUAL"
+                            },
+                            "value": {
+                                "description": "Meter read value.  If positive then it means consumption, if negative it means export",
+                                "type": "number"
+                            }
+                        }
+                    },
+                    "intervalRead": {
+                        "description": "Mandatory if readUType is set to intervalRead",
+                        "type": "object",
+                        "required": [
+                            "readIntervalLength",
+                            "aggregateValue",
+                            "intervalReads"
+                        ],
+                        "properties": {
+                            "readIntervalLength": {
+                                "description": "Read interval length in minutes",
+                                "type": "string",
+                                "x-cds-type": "PositiveInteger"
+                            },
+                            "aggregateValue": {
+                                "description": "The aggregate sum of the interval read values. If positive then it means net consumption, if negative it means net export",
+                                "type": "number"
+                            },
+                            "intervalReads": {
+                                "description": "Array of reads with each element indicating the read for the interval specified by readIntervalLength beginning at midnight of readStartDate (for example 00:00 to 00:30 would be the first reading in a 30 minute Interval)",
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "value"
+                                    ],
+                                    "properties": {
+                                        "quality": {
+                                            "description": "The quality of the read taken.  If absent then assumed to be ACTUAL",
+                                            "type": "string",
+                                            "enum": [
+                                                "ACTUAL",
+                                                "SUBSTITUTE",
+                                                "FINAL_SUBSTITUTE"
+                                            ],
+                                            "default": "ACTUAL"
+                                        },
+                                        "value": {
+                                            "description": "Interval value.  If positive then it means consumption, if negative it means export",
+                                            "type": "number"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "EnergyDerRecord": {
+				"type": "object",
+				"required": [
+					"servicePointId",
+					"approvedCapacity",
+					"availablePhasesCount",
+					"installedPhasesCount",
+					"islandableInstallation",
+					"acConnections"
+				],
+				"x-conditional": [
+					"protectionMode"
+				],
+				"properties": {
+					"servicePointId": {
+                    "description": "The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.",
+						"type": "string"
+					},
+					"approvedCapacity": {
+						"description": "Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA",
+						"type": "number"
+					},
+					"availablePhasesCount": {
+						"description": "The number of phases available for the installation of DER",
+						"type": "number"
+					},
+					"installedPhasesCount": {
+						"description": "The number of phases that DER is connected to",
+						"type": "number"
+					},
+					"islandableInstallation": {
+						"description": "For identification of small generating units designed with the ability to operate in an islanded mode",
+						"type": "string"
+					},
+					"hasCentralProtectionControl": {
+						"description": "For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false",
+						"type": "boolean",
+						"default": false
+					},
+					"protectionMode": {
+						"description": "Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place",
+						"type": "object",
+						"properties": {
+							"exportLimitkva": {
+								"description": "Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit",
+								"type": "number"
+							},
+							"underFrequencyProtection": {
+								"description": "Protective function limit in Hz.",
+								"type": "number"
+							},
+							"underFrequencyProtectionDelay": {
+								"description": "Trip delay time in seconds.",
+								"type": "number"
+							},
+							"overFrequencyProtection": {
+								"description": "Protective function limit in Hz.",
+								"type": "number"
+							},
+							"overFrequencyProtectionDelay": {
+								"description": "Trip delay time in seconds.",
+								"type": "number"
+							},
+							"underVoltageProtection": {
+								"description": "Protective function limit in V.",
+								"type": "number"
+							},
+							"underVoltageProtectionDelay": {
+								"description": "Trip delay time in seconds.",
+								"type": "number"
+							},
+							"overVoltageProtection": {
+								"description": "Protective function limit in V.",
+								"type": "number"
+							},
+							"overVoltageProtectionDelay": {
+								"description": "Trip delay time in seconds.",
+								"type": "number"
+							},
+							"sustainedOverVoltage": {
+								"description": "Sustained over voltage.",
+								"type": "number"
+							},
+							"sustainedOverVoltageDelay": {
+								"description": "Trip delay time in seconds.",
+								"type": "number"
+							},
+							"frequencyRateOfChange": {
+								"description": "Rate of change of frequency trip point (Hz/s).",
+								"type": "number"
+							},
+							"voltageVectorShift": {
+								"description": "Trip angle in degrees.",
+								"type": "number"
+							},
+							"interTripScheme": {
+								"description": "Description of the form of inter-trip (e.g. 'from local substation').",
+								"type": "string"
+							},
+							"neutralVoltageDisplacement": {
+								"description": "Trip voltage.",
+								"type": "number"
+							}
+						}
+					},
+					"acConnections": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"required": [
+								"connectionIdentifier",
+								"count",
+								"commissioningDate",
+								"status",
+								"derDevices"
+							],
+							"x-conditional": [
+								"manufacturerName",
+								"inverterSeries",
+								"inverterModelNumber",
+								"inverterDeviceCapacity"
+							],
+							"properties": {
+								"connectionIdentifier": {
+									"description": "AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards",
+									"type": "number"
+								},
+								"count": {
+									"description": "Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes",
+									"type": "string",
+									"x-cds-type": "PositiveInteger"
+								},
+								"equipmentType": {
+									"description": "Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.",
+									"type": "string",
+									"enum": [
+										"INVERTER",
+										"OTHER"
+									]
+								},
+								"manufacturerName": {
+									"description": "The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER",
+									"type": "string"
+								},
+								"inverterSeries": {
+									"description": "The inverter series. Mandatory if equipmentType is INVERTER",
+									"type": "string"
+								},
+								"inverterModelNumber": {
+									"description": "The inverter model number. Mandatory if equipmentType is INVERTER",
+									"type": "string"
+								},
+								"commissioningDate": {
+									"description": "The date that the DER installation is commissioned",
+									"type": "string",
+									"x-cds-type": "DateString"
+								},
+								"status": {
+									"description": "Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned",
+									"type": "string",
+									"enum": [
+										"ACTIVE",
+										"INACTIVE",
+										"DECOMMISSIONED"
+									]
+								},
+								"inverterDeviceCapacity": {
+									"description": "The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER",
+									"type": "number"
+								},
+								"derDevices": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"required": [
+											"deviceIdentifier",
+											"count",
+											"type",
+											"nominalRatedCapacity"
+										],
+										"x-conditional": ["nominalStorageCapacity"],
+										"properties": {
+											"deviceIdentifier": {
+												"description": "Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards",
+												"type": "number"
+											},
+											"count": {
+												"description": "Number of devices in the group of DER devices",
+												"type": "number"
+											},
+											"manufacturer": {
+												"description": "The name of the device manufacturer. If absent then assumed to be “unknown”",
+												"type": "string"
+											},
+											"modelNumber": {
+												"description": "The model number of the device. If absent then assumed to be “unknown”",
+												"type": "string"
+											},
+											"status": {
+												"description": "Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned",
+												"type": "string",
+												"enum": [
+													"ACTIVE",
+													"INACTIVE",
+													"DECOMMISSIONED"
+												]
+											},
+											"type": {
+												"description": "Used to indicate the primary technology used in the DER device",
+												"type": "string",
+												"enum": [
+													"FOSSIL",
+													"HYDRO",
+													"WIND",
+													"SOLAR_PV",
+													"RENEWABLE",
+													"GEOTHERMAL",
+													"STORAGE",
+													"OTHER"
+												]
+											},
+											"subtype": {
+												"description": "Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”",
+												"type": "string"
+											},
+											"nominalRatedCapacity": {
+												"description": "Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group",
+												"type": "number"
+											},
+											"nominalStorageCapacity": {
+												"description": "Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”",
+												"type": "number"
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			"Links": {
+				"type": "object",
+				"required": ["self"],
+				"properties": {
+					"self": {
+						"type": "string",
+						"description": "Fully qualified link that generated the current response document",
+						"x-cds-type": "URIString"
+					}
+				}
+			},
+			"Meta": {
+				"type": "object"
+			},
+			"LinksPaginated": {
+				"type": "object",
+				"required": ["self"],
+				"x-conditional": [
+					"first",
+					"prev",
+					"next",
+					"last"
+				],
+				"properties": {
+					"self": {
+						"type": "string",
+						"description": "Fully qualified link that generated the current response document",
+						"x-cds-type": "URIString"
+					},
+					"first": {
+						"type": "string",
+						"description": "URI to the first page of this set. Mandatory if this response is not the first page",
+						"x-cds-type": "URIString"
+					},
+					"prev": {
+						"type": "string",
+						"description": "URI to the previous page of this set. Mandatory if this response is not the first page",
+						"x-cds-type": "URIString"
+					},
+					"next": {
+						"type": "string",
+						"description": "URI to the next page of this set. Mandatory if this response is not the last page",
+						"x-cds-type": "URIString"
+					},
+					"last": {
+						"type": "string",
+						"description": "URI to the last page of this set. Mandatory if this response is not the last page",
+						"x-cds-type": "URIString"
+					}
+				}
+			},
+			"MetaPaginated": {
+				"type": "object",
+				"required": ["totalPages", "totalRecords"],
+				"properties": {
+					"totalRecords": {
+						"type": "integer",
+						"description": "The total number of records in the full set. See [pagination](#pagination).",
+						"x-cds-type": "NaturalNumber"
+					},
+					"totalPages": {
+						"type": "integer",
+						"description": "The total number of pages in the full set. See [pagination](#pagination).",
+						"x-cds-type": "NaturalNumber"
+					}
+				}
+			}
+		},
+		"parameters": {
+			"servicePointId": {
+				"name": "servicePointId",
+                "description": "The independent ID of the service point, known in the industry as the NMI. The  servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			"newest-time": {
+				"name": "newest-time",
+				"in": "query",
+				"description": "Constrain the request to records with effective time at or before this date/time.  If absent defaults to current date/time.  Format is aligned to DateTimeString common type",
+				"required": false,
+				"schema": {
+					"type": "string"
+				},
+				"x-cds-type": "DateTimeString"
+			},
+			"oldest-time": {
+				"name": "oldest-time",
+				"in": "query",
+				"description": "Constrain the request to records with effective time at or after this date/time. If absent defaults to newest-time minus 12 months.  Format is aligned to DateTimeString common type",
+				"required": false,
+				"schema": {
+					"type": "string"
+				},
+				"x-cds-type": "DateTimeString"
+			},
+			"newest-date": {
+				"name": "newest-date",
+				"in": "query",
+				"description": "Constrain the request to records with effective date at or before this date.  If absent defaults to current date.  Format is aligned to DateString common type",
+				"required": false,
+				"schema": {
+					"type": "string"
+				},
+				"x-cds-type": "DateString"
+			},
+			"oldest-date": {
+				"name": "oldest-date",
+				"in": "query",
+				"description": "Constrain the request to records with effective date at or after this date. If absent defaults to newest-date minus 24 months days.  Format is aligned to DateString common type",
+				"required": false,
+				"schema": {
+					"type": "string"
+				},
+				"x-cds-type": "DateString"
+			},
+			"page": {
+				"name": "page",
+				"description": "Page of results to request (standard pagination)",
+				"in": "query",
+				"required": false,
+				"schema": {
+					"type": "number",
+					"default": "1"
+				}
+			},
+			"page-size": {
+				"name": "page-size",
+				"description": "Page size to request.  Default is 25 (standard pagination)",
+				"in": "query",
+				"required": false,
+				"schema": {
+					"type": "number",
+					"default": "25"
+				}
+			},
+			"x-v": {
+				"name": "x-v",
+				"description": "Version of the API end point requested by the client. Must be set to a positive integer. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If the value of [x-min-v](#request-headers) is equal to or higher than the value of [x-v](#request-headers) then the [x-min-v](#request-headers) header should be treated as absent. If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable. See [HTTP Headers](#request-headers)",
+				"in": "header",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			"x-min-v": {
+				"name": "x-min-v",
+				"description": "Minimum version of the API end point requested by the client. Must be set to a positive integer if provided. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable.",
+				"in": "header",
+				"required": false,
+				"schema": {
+					"type": "string"
+				}
+			},
+			"x-fapi-interaction-id": {
+				"name": "x-fapi-interaction-id",
+				"description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction.",
+				"in": "header",
+				"required": false,
+				"schema": {
+					"type": "string"
+				}
+			},
+            "x-cds-arrangement": {
+				"name": "x-cds-arrangement",
+				"description": "A unique string representing a consent arrangement between a Data Recipient Software Product and Data Holder for a given consumer. The identifier MUST be unique per customer according to the definition of customer in the CDR Federation section of this profile. The x-cds-arrangement should contain the arrangement ID for the consent that the request is being made under and will be used for tracing and audit purposes. This field MUST be populated but AEMO MUST NOT seek to validate the consent associated with the arrangement",
+				"in": "header",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			}
+		},
+		"requestBodies": {
+			"servicePointIdList": {
+				"description": "Request payload containing list of specific Service Points to obtain data for",
+				"required": true,
+				"content": {
+					"application/json": {
+						"schema": {
+							"type": "object",
+							"required": [
+								"data",
+								"meta"
+							],
+							"properties": {
+								"data": {
+									"type": "object",
+									"required": [
+										"servicePointIds"
+									],
+									"properties": {
+										"servicePointIds": {
+											"description": "Array of specific NMIs to obtain data for",
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										}
+									}
+								},
+								"meta": {
+									"$ref": "#/components/schemas/Meta"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"responses": {
+			"servicePointList": {
+				"description": "Successful response",
+                "headers": {
+                    "x-v": {
+                        "schema": {
+                            "type": "string",
+                            "description": "The [version](#response-headers) of the API end point that the data holder has responded with."
+                        }
+                    },
+                    "x-fapi-interaction-id": {
+                        "schema": {
+                            "type": "string",
+                            "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                        }
+                    }
+                },
+				"content": {
+					"application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/EnergyServicePointListResponse"
+						}
+					}
+				}
+			},
+			"servicePointDetail": {
+				"description": "Successful response",
+                "headers": {
+                    "x-v": {
+                        "schema": {
+                            "type": "string",
+                            "description": "The [version](#response-headers) of the API end point that the data holder has responded with."
+                        }
+                    },
+                    "x-fapi-interaction-id": {
+                        "schema": {
+                            "type": "string",
+                            "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                        }
+                    }
+                },
+				"content": {
+					"application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/EnergyServicePointDetailResponse"
+						}
+					}
+				}
+			},
+			"usageList": {
+				"description": "Successful response",
+                "headers": {
+                    "x-v": {
+                        "schema": {
+                            "type": "string",
+                            "description": "The [version](#response-headers) of the API end point that the data holder has responded with."
+                        }
+                    },
+                    "x-fapi-interaction-id": {
+                        "schema": {
+                            "type": "string",
+                            "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                        }
+                    }
+                },
+				"content": {
+					"application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/EnergyUsageListResponse"
+						}
+					}
+				}
+			},
+			"derList": {
+				"description": "Successful response",
+                "headers": {
+                    "x-v": {
+                        "schema": {
+                            "type": "string",
+                            "description": "The [version](#response-headers) of the API end point that the data holder has responded with."
+                        }
+                    },
+                    "x-fapi-interaction-id": {
+                        "schema": {
+                            "type": "string",
+                            "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                        }
+                    }
+                },
+				"content": {
+					"application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/EnergyDerListResponse"
+						}
+					}
+				}
+			},
+			"derDetail": {
+				"description": "Successful response",
+                "headers": {
+                    "x-v": {
+                        "schema": {
+                            "type": "string",
+                            "description": "The [version](#response-headers) of the API end point that the data holder has responded with."
+                        }
+                    },
+                    "x-fapi-interaction-id": {
+                        "schema": {
+                            "type": "string",
+                            "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                        }
+                    }
+                },
+				"content": {
+					"application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/EnergyDerDetailResponse"
+						}
+					}
+				}
+			}
+		}
+	},
+	"paths": {
+		"/secondary/energy/electricity/servicepoints": {
+			"post": {
+				"summary": "Get Service Points",
+				"description": "Obtain a list of service points owned by the customer that has authorised the current session",
+				"operationId": "listServicePoints",
+				"x-scopes": [
+					"energy:electricity.servicepoints.basic:read"
+				],
+				"tags": [
+                    "Energy-SDH",
+					"NMI Standing Data"
+				],
+                "x-version": "1",
+				"parameters": [{
+						"$ref": "#/components/parameters/page"
+					},
+					{
+						"$ref": "#/components/parameters/page-size"
+					},
+					{
+						"$ref": "#/components/parameters/x-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-min-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-fapi-interaction-id"
+					},
+                    {
+						"$ref": "#/components/parameters/x-cds-arrangement"
+					}
+				],
+                "requestBody": {
+					"$ref": "#/components/requestBodies/servicePointIdList"
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/servicePointList"
+                    },
+                    "4xx": {
+                        "description": "The following error codes MUST be supported:<br/><ul class=\"error-code-list\"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Page Size](#error-400-field-invalid-page-size)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[422 - Invalid Page](#error-422-field-invalid-page)</li></ul>",
+                        "headers": {
+                            "x-fapi-interaction-id": {
+                                "schema": {
+                                    "type": "string",
+                                    "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                                }
+                            }
+                        },
+                        "content": {
+        					"application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorListResponse"
+        						}
+        					}
+        				}
+                    }
+				}
+			}
+		},
+		"/secondary/energy/electricity/servicepoints/{servicePointId}": {
+			"get": {
+				"summary": "Get Service Point Detail",
+				"operationId": "getServicePoint",
+				"x-scopes": [
+					"energy:electricity.servicepoints.detail:read"
+				],
+				"description": "Obtain detailed standing information for a specific service point that is owned by the customer that has authorised the current session",
+				"tags": [
+                    "Energy-SDH",
+					"NMI Standing Data"
+				],
+                "x-version": "1",
+				"parameters": [{
+						"$ref": "#/components/parameters/servicePointId"
+					},
+					{
+						"$ref": "#/components/parameters/x-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-min-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-fapi-interaction-id"
+					},
+                    {
+						"$ref": "#/components/parameters/x-cds-arrangement"
+					}
+				],
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/servicePointDetail"
+                    },
+                    "4xx": {
+                        "description": "The following error codes MUST be supported:<br/><ul class=\"error-code-list\"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[404 - Unavailable Service Point](#error-404-unavailable-service-point)</li><li>[404 - Invalid Service Point](#error-404-invalid-service-point)</li></ul>",
+                        "headers": {
+                            "x-fapi-interaction-id": {
+                                "schema": {
+                                    "type": "string",
+                                    "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                                }
+                            }
+                        },
+                        "content": {
+        					"application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorListResponse"
+        						}
+        					}
+        				}
+                    }
+				}
+			}
+		},
+		"/secondary/energy/electricity/servicepoints/{servicePointId}/usage": {
+			"get": {
+				"summary": "Get Usage For Service Point",
+				"operationId": "getUsageForServicePoint",
+                "x-scopes": [
+					"energy:electricity.usage:read"
+				],
+				"description": "Obtain a list of electricity usage data from a particular service point",
+				"tags": [
+                    "Energy-SDH",
+					"Electricity Usage"
+				],
+                "x-version": "1",
+				"parameters": [{
+						"$ref": "#/components/parameters/servicePointId"
+					},
+                    {
+						"$ref": "#/components/parameters/oldest-date"
+					},
+					{
+						"$ref": "#/components/parameters/newest-date"
+					},
+					{
+						"$ref": "#/components/parameters/page"
+					},
+					{
+						"$ref": "#/components/parameters/page-size"
+					},
+					{
+						"$ref": "#/components/parameters/x-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-min-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-fapi-interaction-id"
+					},
+                    {
+						"$ref": "#/components/parameters/x-cds-arrangement"
+					}
+				],
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/usageList"
+                    },
+                    "4xx": {
+                        "description": "The following error codes MUST be supported:<br/><ul class=\"error-code-list\"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Page Size](#error-400-field-invalid-page-size)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[422 - Invalid Page](#error-422-field-invalid-page)</li><li>[404 - Unavailable Service Point](#error-404-unavailable-service-point)</li><li>[404 - Invalid Service Point](#error-404-invalid-service-point)</li></ul>",
+                        "headers": {
+                            "x-fapi-interaction-id": {
+                                "schema": {
+                                    "type": "string",
+                                    "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                                }
+                            }
+                        },
+                        "content": {
+        					"application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorListResponse"
+        						}
+        					}
+        				}
+                    }
+				}
+			}
+		},
+		"/secondary/energy/electricity/servicepoints/usage": {
+			"post": {
+				"summary": "Get Usage For Specific Service Points",
+				"operationId": "listUsageForServicePoints",
+                "x-scopes": [
+					"energy:electricity.usage:read"
+                ],
+				"description": "Obtain the electricity usage data for a specific set of service points",
+				"tags": [
+                    "Energy-SDH",
+					"Electricity Usage"
+				],
+                "x-version": "1",
+				"parameters": [{
+                        "$ref": "#/components/parameters/oldest-date"
+                    },
+                    {
+                        "$ref": "#/components/parameters/newest-date"
+                    },
+                    {
+						"$ref": "#/components/parameters/page"
+					},
+					{
+						"$ref": "#/components/parameters/page-size"
+					},
+					{
+						"$ref": "#/components/parameters/x-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-min-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-fapi-interaction-id"
+					},
+                    {
+						"$ref": "#/components/parameters/x-cds-arrangement"
+					}
+				],
+				"requestBody": {
+					"$ref": "#/components/requestBodies/servicePointIdList"
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/usageList"
+                    },
+                    "4xx": {
+                        "description": "The following error codes MUST be supported:<br/><ul class=\"error-code-list\"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Page Size](#error-400-field-invalid-page-size)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[422 - Invalid Page](#error-422-field-invalid-page)</li><li>[422 - Unavailable Service Point](#error-422-unavailable-service-point)</li><li>[422 - Invalid Service Point](#error-422-invalid-service-point)</li></ul>",
+                        "headers": {
+                            "x-fapi-interaction-id": {
+                                "schema": {
+                                    "type": "string",
+                                    "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                                }
+                            }
+                        },
+                        "content": {
+        					"application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorListResponse"
+        						}
+        					}
+        				}
+                    }
+				}
+			}
+		},
+		"/secondary/energy/electricity/servicepoints/{servicePointId}/der": {
+			"get": {
+				"summary": "Get DER For Service Point",
+				"operationId": "getDERForServicePoint",
+				"description": "Obtain a list of DER data from a particular service point",
+				"x-scopes": [
+                    "energy:electricity.der:read"
+                ],
+				"tags": [
+                    "Energy-SDH",
+					"Distributed Energy Resources"
+				],
+                "x-version": "1",
+				"parameters": [{
+						"$ref": "#/components/parameters/servicePointId"
+					},
+					{
+						"$ref": "#/components/parameters/x-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-min-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-fapi-interaction-id"
+					},
+                    {
+						"$ref": "#/components/parameters/x-cds-arrangement"
+					}
+				],
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/derDetail"
+                    },
+                    "4xx": {
+                        "description": "The following error codes MUST be supported:<br/><ul class=\"error-code-list\"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[404 - Unavailable Service Point](#error-404-unavailable-service-point)</li><li>[404 - Invalid Service Point](#error-404-invalid-service-point)</li></ul>",
+                        "headers": {
+                            "x-fapi-interaction-id": {
+                                "schema": {
+                                    "type": "string",
+                                    "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                                }
+                            }
+                        },
+                        "content": {
+        					"application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorListResponse"
+        						}
+        					}
+        				}
+                    }
+				}
+			}
+		},
+		"/secondary/energy/electricity/servicepoints/der": {
+			"post": {
+				"summary": "Get DER For Specific Service Points",
+				"operationId": "listDERForServicePoints",
+				"description": "Obtain DER data for a specific set of service points",
+				"x-scopes": [
+                    "energy:electricity.der:read"
+                ],
+				"tags": [
+                    "Energy-SDH",
+					"Distributed Energy Resources"
+				],
+                "x-version": "1",
+				"parameters": [{
+						"$ref": "#/components/parameters/page"
+					},
+					{
+						"$ref": "#/components/parameters/page-size"
+					},
+					{
+						"$ref": "#/components/parameters/x-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-min-v"
+					},
+					{
+						"$ref": "#/components/parameters/x-fapi-interaction-id"
+					},
+                    {
+						"$ref": "#/components/parameters/x-cds-arrangement"
+					}
+				],
+				"requestBody": {
+					"$ref": "#/components/requestBodies/servicePointIdList"
+				},
+				"responses": {
+					"200": {
+						"$ref": "#/components/responses/derList"
+                    },
+                    "4xx": {
+                        "description": "The following error codes MUST be supported:<br/><ul class=\"error-code-list\"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Page Size](#error-400-field-invalid-page-size)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[422 - Invalid Page](#error-422-field-invalid-page)</li><li>[422 - Unavailable Service Point](#error-422-unavailable-service-point)</li><li>[422 - Invalid Service Point](#error-422-invalid-service-point)</li></ul>",
+                        "headers": {
+                            "x-fapi-interaction-id": {
+                                "schema": {
+                                    "type": "string",
+                                    "description": "An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction."
+                                }
+                            }
+                        },
+                        "content": {
+        					"application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorListResponse"
+        						}
+        					}
+        				}
+                    }
+				}
+			}
+		}
+	}
+}

--- a/swagger-gen/cds_energy_sdh.md
+++ b/swagger-gen/cds_energy_sdh.md
@@ -1,0 +1,1924 @@
+
+
+## Get Service Points
+
+<a id="opIdlistServicePoints"></a>
+
+> Code samples
+
+```http
+POST /secondary/energy/electricity/servicepoints HTTP/1.1
+
+Content-Type: application/json
+Accept: application/json
+x-v: string
+x-min-v: string
+x-fapi-interaction-id: string
+x-cds-arrangement: string
+
+```
+
+```javascript
+var headers = {
+  'Content-Type':'application/json',
+  'Accept':'application/json',
+  'x-v':'string',
+  'x-min-v':'string',
+  'x-fapi-interaction-id':'string',
+  'x-cds-arrangement':'string'
+
+};
+
+$.ajax({
+  url: '/secondary/energy/electricity/servicepoints',
+  method: 'post',
+
+  headers: headers,
+  success: function(data) {
+    console.log(JSON.stringify(data));
+  }
+})
+
+```
+
+`POST /secondary/energy/electricity/servicepoints`
+
+Obtain a list of service points owned by the customer that has authorised the current session
+
+> Body parameter
+
+```json
+{
+  "data": {
+    "servicePointIds": [
+      "string"
+    ]
+  },
+  "meta": {}
+}
+```
+
+###Endpoint Version
+|   |  |
+|---|--|
+|Version|**1**
+
+<h3 id="get-service-points-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|page|query|number|optional|Page of results to request (standard pagination)|
+|page-size|query|number|optional|Page size to request.  Default is 25 (standard pagination)|
+|x-v|header|string|mandatory|Version of the API end point requested by the client. Must be set to a positive integer. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If the value of [x-min-v](#request-headers) is equal to or higher than the value of [x-v](#request-headers) then the [x-min-v](#request-headers) header should be treated as absent. If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable. See [HTTP Headers](#request-headers)|
+|x-min-v|header|string|optional|Minimum version of the API end point requested by the client. Must be set to a positive integer if provided. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable.|
+|x-fapi-interaction-id|header|string|optional|An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction.|
+|x-cds-arrangement|header|string|mandatory|A unique string representing a consent arrangement between a Data Recipient Software Product and Data Holder for a given consumer. The identifier MUST be unique per customer according to the definition of customer in the CDR Federation section of this profile. The x-cds-arrangement should contain the arrangement ID for the consent that the request is being made under and will be used for tracing and audit purposes. This field MUST be populated but AEMO MUST NOT seek to validate the consent associated with the arrangement|
+|body|body|[servicePointIdList](#schemacdr-energy-secondary-data-holder-apiservicepointidlist)|mandatory|Request payload containing list of specific Service Points to obtain data for|
+|» data|body|object|mandatory|none|
+|»» servicePointIds|body|[string]|mandatory|Array of specific NMIs to obtain data for|
+|» meta|body|[Meta](#schemacdr-energy-secondary-data-holder-apimeta)|mandatory|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "servicePoints": [
+      {
+        "servicePointId": "string",
+        "nationalMeteringId": "string",
+        "servicePointClassification": "EXTERNAL_PROFILE",
+        "servicePointStatus": "ACTIVE",
+        "jurisdictionCode": "ALL",
+        "isGenerator": true,
+        "validFromDate": "string",
+        "lastUpdateDateTime": "string",
+        "consumerProfile": {
+          "classification": "BUSINESS",
+          "threshold": "LOW"
+        }
+      }
+    ]
+  },
+  "links": {
+    "self": "string",
+    "first": "string",
+    "prev": "string",
+    "next": "string",
+    "last": "string"
+  },
+  "meta": {
+    "totalRecords": 0,
+    "totalPages": 0
+  }
+}
+```
+
+<h3 id="get-service-points-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response|[EnergyServicePointListResponse](#schemacdr-energy-secondary-data-holder-apienergyservicepointlistresponse)|
+|4xx|[**Client Error**](https://tools.ietf.org/html/rfc7231#section-6.5)|The following error codes MUST be supported:<br/><ul class="error-code-list"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Page Size](#error-400-field-invalid-page-size)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[422 - Invalid Page](#error-422-field-invalid-page)</li></ul>|[ErrorListResponse](#schemacdr-energy-secondary-data-holder-apierrorlistresponse)|
+
+### Response Headers
+
+|Status|Header|Type|Format|Description|
+|---|---|---|---|---|
+|200|x-v|string||none|
+|200|x-fapi-interaction-id|string||none|
+|4xx|x-fapi-interaction-id|string||none|
+
+  
+    
+      <aside class="notice">
+To perform this operation, you must be authenticated and authorised with the following scopes:
+<a href="#authorisation-scopes">energy:electricity.servicepoints.basic:read</a>
+</aside>
+
+    
+  
+
+## Get Service Point Detail
+
+<a id="opIdgetServicePoint"></a>
+
+> Code samples
+
+```http
+GET /secondary/energy/electricity/servicepoints/{servicePointId} HTTP/1.1
+
+Accept: application/json
+x-v: string
+x-min-v: string
+x-fapi-interaction-id: string
+x-cds-arrangement: string
+
+```
+
+```javascript
+var headers = {
+  'Accept':'application/json',
+  'x-v':'string',
+  'x-min-v':'string',
+  'x-fapi-interaction-id':'string',
+  'x-cds-arrangement':'string'
+
+};
+
+$.ajax({
+  url: '/secondary/energy/electricity/servicepoints/{servicePointId}',
+  method: 'get',
+
+  headers: headers,
+  success: function(data) {
+    console.log(JSON.stringify(data));
+  }
+})
+
+```
+
+`GET /secondary/energy/electricity/servicepoints/{servicePointId}`
+
+Obtain detailed standing information for a specific service point that is owned by the customer that has authorised the current session
+
+###Endpoint Version
+|   |  |
+|---|--|
+|Version|**1**
+
+<h3 id="get-service-point-detail-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|servicePointId|path|string|mandatory|The independent ID of the service point, known in the industry as the NMI. The  servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.|
+|x-v|header|string|mandatory|Version of the API end point requested by the client. Must be set to a positive integer. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If the value of [x-min-v](#request-headers) is equal to or higher than the value of [x-v](#request-headers) then the [x-min-v](#request-headers) header should be treated as absent. If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable. See [HTTP Headers](#request-headers)|
+|x-min-v|header|string|optional|Minimum version of the API end point requested by the client. Must be set to a positive integer if provided. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable.|
+|x-fapi-interaction-id|header|string|optional|An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction.|
+|x-cds-arrangement|header|string|mandatory|A unique string representing a consent arrangement between a Data Recipient Software Product and Data Holder for a given consumer. The identifier MUST be unique per customer according to the definition of customer in the CDR Federation section of this profile. The x-cds-arrangement should contain the arrangement ID for the consent that the request is being made under and will be used for tracing and audit purposes. This field MUST be populated but AEMO MUST NOT seek to validate the consent associated with the arrangement|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "servicePointId": "string",
+    "nationalMeteringId": "string",
+    "servicePointClassification": "EXTERNAL_PROFILE",
+    "servicePointStatus": "ACTIVE",
+    "jurisdictionCode": "ALL",
+    "isGenerator": true,
+    "validFromDate": "string",
+    "lastUpdateDateTime": "string",
+    "consumerProfile": {
+      "classification": "BUSINESS",
+      "threshold": "LOW"
+    },
+    "distributionLossFactor": {
+      "code": "string",
+      "description": "string",
+      "lossValue": "string"
+    },
+    "relatedParticipants": [
+      {
+        "party": "string",
+        "role": "FRMP"
+      }
+    ],
+    "location": {
+      "addressUType": "simple",
+      "simple": {
+        "mailingName": "string",
+        "addressLine1": "string",
+        "addressLine2": "string",
+        "addressLine3": "string",
+        "postcode": "string",
+        "city": "string",
+        "state": "string",
+        "country": "AUS"
+      },
+      "paf": {
+        "dpid": "string",
+        "thoroughfareNumber1": 0,
+        "thoroughfareNumber1Suffix": "string",
+        "thoroughfareNumber2": 0,
+        "thoroughfareNumber2Suffix": "string",
+        "flatUnitType": "string",
+        "flatUnitNumber": "string",
+        "floorLevelType": "string",
+        "floorLevelNumber": "string",
+        "lotNumber": "string",
+        "buildingName1": "string",
+        "buildingName2": "string",
+        "streetName": "string",
+        "streetType": "string",
+        "streetSuffix": "string",
+        "postalDeliveryType": "string",
+        "postalDeliveryNumber": 0,
+        "postalDeliveryNumberPrefix": "string",
+        "postalDeliveryNumberSuffix": "string",
+        "localityName": "string",
+        "postcode": "string",
+        "state": "string"
+      }
+    },
+    "meters": {
+      "meterId": "string",
+      "specifications": {
+        "status": "CURRENT",
+        "installationType": "BASIC",
+        "manufacturer": "string",
+        "model": "string",
+        "readType": "string",
+        "nextScheduledReadDate": "string"
+      },
+      "registers": {
+        "registerId": "string",
+        "registerSuffix": "string",
+        "averagedDailyLoad": 0,
+        "registerConsumptionType": "INTERVAL",
+        "networkTariffCode": "string",
+        "unitOfMeasure": "string",
+        "timeOfDay": "ALLDAY",
+        "multiplier": 0,
+        "controlledLoad": true,
+        "consumptionType": "ACTUAL"
+      }
+    }
+  },
+  "links": {
+    "self": "string"
+  },
+  "meta": {}
+}
+```
+
+<h3 id="get-service-point-detail-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response|[EnergyServicePointDetailResponse](#schemacdr-energy-secondary-data-holder-apienergyservicepointdetailresponse)|
+|4xx|[**Client Error**](https://tools.ietf.org/html/rfc7231#section-6.5)|The following error codes MUST be supported:<br/><ul class="error-code-list"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[404 - Unavailable Service Point](#error-404-unavailable-service-point)</li><li>[404 - Invalid Service Point](#error-404-invalid-service-point)</li></ul>|[ErrorListResponse](#schemacdr-energy-secondary-data-holder-apierrorlistresponse)|
+
+### Response Headers
+
+|Status|Header|Type|Format|Description|
+|---|---|---|---|---|
+|200|x-v|string||none|
+|200|x-fapi-interaction-id|string||none|
+|4xx|x-fapi-interaction-id|string||none|
+
+  
+    
+      <aside class="notice">
+To perform this operation, you must be authenticated and authorised with the following scopes:
+<a href="#authorisation-scopes">energy:electricity.servicepoints.detail:read</a>
+</aside>
+
+    
+  
+
+## Get Usage For Service Point
+
+<a id="opIdgetUsageForServicePoint"></a>
+
+> Code samples
+
+```http
+GET /secondary/energy/electricity/servicepoints/{servicePointId}/usage HTTP/1.1
+
+Accept: application/json
+x-v: string
+x-min-v: string
+x-fapi-interaction-id: string
+x-cds-arrangement: string
+
+```
+
+```javascript
+var headers = {
+  'Accept':'application/json',
+  'x-v':'string',
+  'x-min-v':'string',
+  'x-fapi-interaction-id':'string',
+  'x-cds-arrangement':'string'
+
+};
+
+$.ajax({
+  url: '/secondary/energy/electricity/servicepoints/{servicePointId}/usage',
+  method: 'get',
+
+  headers: headers,
+  success: function(data) {
+    console.log(JSON.stringify(data));
+  }
+})
+
+```
+
+`GET /secondary/energy/electricity/servicepoints/{servicePointId}/usage`
+
+Obtain a list of electricity usage data from a particular service point
+
+###Endpoint Version
+|   |  |
+|---|--|
+|Version|**1**
+
+<h3 id="get-usage-for-service-point-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|servicePointId|path|string|mandatory|The independent ID of the service point, known in the industry as the NMI. The  servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.|
+|oldest-date|query|[DateString](#common-field-types)|optional|Constrain the request to records with effective date at or after this date. If absent defaults to newest-date minus 24 months days.  Format is aligned to DateString common type|
+|newest-date|query|[DateString](#common-field-types)|optional|Constrain the request to records with effective date at or before this date.  If absent defaults to current date.  Format is aligned to DateString common type|
+|page|query|number|optional|Page of results to request (standard pagination)|
+|page-size|query|number|optional|Page size to request.  Default is 25 (standard pagination)|
+|x-v|header|string|mandatory|Version of the API end point requested by the client. Must be set to a positive integer. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If the value of [x-min-v](#request-headers) is equal to or higher than the value of [x-v](#request-headers) then the [x-min-v](#request-headers) header should be treated as absent. If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable. See [HTTP Headers](#request-headers)|
+|x-min-v|header|string|optional|Minimum version of the API end point requested by the client. Must be set to a positive integer if provided. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable.|
+|x-fapi-interaction-id|header|string|optional|An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction.|
+|x-cds-arrangement|header|string|mandatory|A unique string representing a consent arrangement between a Data Recipient Software Product and Data Holder for a given consumer. The identifier MUST be unique per customer according to the definition of customer in the CDR Federation section of this profile. The x-cds-arrangement should contain the arrangement ID for the consent that the request is being made under and will be used for tracing and audit purposes. This field MUST be populated but AEMO MUST NOT seek to validate the consent associated with the arrangement|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "reads": [
+      {
+        "servicePointId": "string",
+        "registerId": "string",
+        "registerSuffix": "string",
+        "meterID": "string",
+        "controlledLoad": true,
+        "readStartDate": "string",
+        "readEndDate": "string",
+        "unitOfMeasure": "string",
+        "readUType": "basicRead",
+        "basicRead": {
+          "quality": "ACTUAL",
+          "value": 0
+        },
+        "intervalRead": {
+          "readIntervalLength": "string",
+          "aggregateValue": 0,
+          "intervalReads": [
+            {
+              "quality": "ACTUAL",
+              "value": 0
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "links": {
+    "self": "string",
+    "first": "string",
+    "prev": "string",
+    "next": "string",
+    "last": "string"
+  },
+  "meta": {
+    "totalRecords": 0,
+    "totalPages": 0
+  }
+}
+```
+
+<h3 id="get-usage-for-service-point-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response|[EnergyUsageListResponse](#schemacdr-energy-secondary-data-holder-apienergyusagelistresponse)|
+|4xx|[**Client Error**](https://tools.ietf.org/html/rfc7231#section-6.5)|The following error codes MUST be supported:<br/><ul class="error-code-list"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Page Size](#error-400-field-invalid-page-size)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[422 - Invalid Page](#error-422-field-invalid-page)</li><li>[404 - Unavailable Service Point](#error-404-unavailable-service-point)</li><li>[404 - Invalid Service Point](#error-404-invalid-service-point)</li></ul>|[ErrorListResponse](#schemacdr-energy-secondary-data-holder-apierrorlistresponse)|
+
+### Response Headers
+
+|Status|Header|Type|Format|Description|
+|---|---|---|---|---|
+|200|x-v|string||none|
+|200|x-fapi-interaction-id|string||none|
+|4xx|x-fapi-interaction-id|string||none|
+
+  
+    
+      <aside class="notice">
+To perform this operation, you must be authenticated and authorised with the following scopes:
+<a href="#authorisation-scopes">energy:electricity.usage:read</a>
+</aside>
+
+    
+  
+
+## Get Usage For Specific Service Points
+
+<a id="opIdlistUsageForServicePoints"></a>
+
+> Code samples
+
+```http
+POST /secondary/energy/electricity/servicepoints/usage HTTP/1.1
+
+Content-Type: application/json
+Accept: application/json
+x-v: string
+x-min-v: string
+x-fapi-interaction-id: string
+x-cds-arrangement: string
+
+```
+
+```javascript
+var headers = {
+  'Content-Type':'application/json',
+  'Accept':'application/json',
+  'x-v':'string',
+  'x-min-v':'string',
+  'x-fapi-interaction-id':'string',
+  'x-cds-arrangement':'string'
+
+};
+
+$.ajax({
+  url: '/secondary/energy/electricity/servicepoints/usage',
+  method: 'post',
+
+  headers: headers,
+  success: function(data) {
+    console.log(JSON.stringify(data));
+  }
+})
+
+```
+
+`POST /secondary/energy/electricity/servicepoints/usage`
+
+Obtain the electricity usage data for a specific set of service points
+
+> Body parameter
+
+```json
+{
+  "data": {
+    "servicePointIds": [
+      "string"
+    ]
+  },
+  "meta": {}
+}
+```
+
+###Endpoint Version
+|   |  |
+|---|--|
+|Version|**1**
+
+<h3 id="get-usage-for-specific-service-points-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|oldest-date|query|[DateString](#common-field-types)|optional|Constrain the request to records with effective date at or after this date. If absent defaults to newest-date minus 24 months days.  Format is aligned to DateString common type|
+|newest-date|query|[DateString](#common-field-types)|optional|Constrain the request to records with effective date at or before this date.  If absent defaults to current date.  Format is aligned to DateString common type|
+|page|query|number|optional|Page of results to request (standard pagination)|
+|page-size|query|number|optional|Page size to request.  Default is 25 (standard pagination)|
+|x-v|header|string|mandatory|Version of the API end point requested by the client. Must be set to a positive integer. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If the value of [x-min-v](#request-headers) is equal to or higher than the value of [x-v](#request-headers) then the [x-min-v](#request-headers) header should be treated as absent. If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable. See [HTTP Headers](#request-headers)|
+|x-min-v|header|string|optional|Minimum version of the API end point requested by the client. Must be set to a positive integer if provided. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable.|
+|x-fapi-interaction-id|header|string|optional|An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction.|
+|x-cds-arrangement|header|string|mandatory|A unique string representing a consent arrangement between a Data Recipient Software Product and Data Holder for a given consumer. The identifier MUST be unique per customer according to the definition of customer in the CDR Federation section of this profile. The x-cds-arrangement should contain the arrangement ID for the consent that the request is being made under and will be used for tracing and audit purposes. This field MUST be populated but AEMO MUST NOT seek to validate the consent associated with the arrangement|
+|body|body|[servicePointIdList](#schemacdr-energy-secondary-data-holder-apiservicepointidlist)|mandatory|Request payload containing list of specific Service Points to obtain data for|
+|» data|body|object|mandatory|none|
+|»» servicePointIds|body|[string]|mandatory|Array of specific NMIs to obtain data for|
+|» meta|body|[Meta](#schemacdr-energy-secondary-data-holder-apimeta)|mandatory|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "reads": [
+      {
+        "servicePointId": "string",
+        "registerId": "string",
+        "registerSuffix": "string",
+        "meterID": "string",
+        "controlledLoad": true,
+        "readStartDate": "string",
+        "readEndDate": "string",
+        "unitOfMeasure": "string",
+        "readUType": "basicRead",
+        "basicRead": {
+          "quality": "ACTUAL",
+          "value": 0
+        },
+        "intervalRead": {
+          "readIntervalLength": "string",
+          "aggregateValue": 0,
+          "intervalReads": [
+            {
+              "quality": "ACTUAL",
+              "value": 0
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "links": {
+    "self": "string",
+    "first": "string",
+    "prev": "string",
+    "next": "string",
+    "last": "string"
+  },
+  "meta": {
+    "totalRecords": 0,
+    "totalPages": 0
+  }
+}
+```
+
+<h3 id="get-usage-for-specific-service-points-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response|[EnergyUsageListResponse](#schemacdr-energy-secondary-data-holder-apienergyusagelistresponse)|
+|4xx|[**Client Error**](https://tools.ietf.org/html/rfc7231#section-6.5)|The following error codes MUST be supported:<br/><ul class="error-code-list"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Page Size](#error-400-field-invalid-page-size)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[422 - Invalid Page](#error-422-field-invalid-page)</li><li>[422 - Unavailable Service Point](#error-422-unavailable-service-point)</li><li>[422 - Invalid Service Point](#error-422-invalid-service-point)</li></ul>|[ErrorListResponse](#schemacdr-energy-secondary-data-holder-apierrorlistresponse)|
+
+### Response Headers
+
+|Status|Header|Type|Format|Description|
+|---|---|---|---|---|
+|200|x-v|string||none|
+|200|x-fapi-interaction-id|string||none|
+|4xx|x-fapi-interaction-id|string||none|
+
+  
+    
+      <aside class="notice">
+To perform this operation, you must be authenticated and authorised with the following scopes:
+<a href="#authorisation-scopes">energy:electricity.usage:read</a>
+</aside>
+
+    
+  
+
+## Get DER For Service Point
+
+<a id="opIdgetDERForServicePoint"></a>
+
+> Code samples
+
+```http
+GET /secondary/energy/electricity/servicepoints/{servicePointId}/der HTTP/1.1
+
+Accept: application/json
+x-v: string
+x-min-v: string
+x-fapi-interaction-id: string
+x-cds-arrangement: string
+
+```
+
+```javascript
+var headers = {
+  'Accept':'application/json',
+  'x-v':'string',
+  'x-min-v':'string',
+  'x-fapi-interaction-id':'string',
+  'x-cds-arrangement':'string'
+
+};
+
+$.ajax({
+  url: '/secondary/energy/electricity/servicepoints/{servicePointId}/der',
+  method: 'get',
+
+  headers: headers,
+  success: function(data) {
+    console.log(JSON.stringify(data));
+  }
+})
+
+```
+
+`GET /secondary/energy/electricity/servicepoints/{servicePointId}/der`
+
+Obtain a list of DER data from a particular service point
+
+###Endpoint Version
+|   |  |
+|---|--|
+|Version|**1**
+
+<h3 id="get-der-for-service-point-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|servicePointId|path|string|mandatory|The independent ID of the service point, known in the industry as the NMI. The  servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.|
+|x-v|header|string|mandatory|Version of the API end point requested by the client. Must be set to a positive integer. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If the value of [x-min-v](#request-headers) is equal to or higher than the value of [x-v](#request-headers) then the [x-min-v](#request-headers) header should be treated as absent. If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable. See [HTTP Headers](#request-headers)|
+|x-min-v|header|string|optional|Minimum version of the API end point requested by the client. Must be set to a positive integer if provided. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable.|
+|x-fapi-interaction-id|header|string|optional|An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction.|
+|x-cds-arrangement|header|string|mandatory|A unique string representing a consent arrangement between a Data Recipient Software Product and Data Holder for a given consumer. The identifier MUST be unique per customer according to the definition of customer in the CDR Federation section of this profile. The x-cds-arrangement should contain the arrangement ID for the consent that the request is being made under and will be used for tracing and audit purposes. This field MUST be populated but AEMO MUST NOT seek to validate the consent associated with the arrangement|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "servicePointId": "string",
+    "approvedCapacity": 0,
+    "availablePhasesCount": 0,
+    "installedPhasesCount": 0,
+    "islandableInstallation": "string",
+    "hasCentralProtectionControl": false,
+    "protectionMode": {
+      "exportLimitkva": 0,
+      "underFrequencyProtection": 0,
+      "underFrequencyProtectionDelay": 0,
+      "overFrequencyProtection": 0,
+      "overFrequencyProtectionDelay": 0,
+      "underVoltageProtection": 0,
+      "underVoltageProtectionDelay": 0,
+      "overVoltageProtection": 0,
+      "overVoltageProtectionDelay": 0,
+      "sustainedOverVoltage": 0,
+      "sustainedOverVoltageDelay": 0,
+      "frequencyRateOfChange": 0,
+      "voltageVectorShift": 0,
+      "interTripScheme": "string",
+      "neutralVoltageDisplacement": 0
+    },
+    "acConnections": [
+      {
+        "connectionIdentifier": 0,
+        "count": "string",
+        "equipmentType": "INVERTER",
+        "manufacturerName": "string",
+        "inverterSeries": "string",
+        "inverterModelNumber": "string",
+        "commissioningDate": "string",
+        "status": "ACTIVE",
+        "inverterDeviceCapacity": 0,
+        "derDevices": [
+          {
+            "deviceIdentifier": 0,
+            "count": 0,
+            "manufacturer": "string",
+            "modelNumber": "string",
+            "status": "ACTIVE",
+            "type": "FOSSIL",
+            "subtype": "string",
+            "nominalRatedCapacity": 0,
+            "nominalStorageCapacity": 0
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "self": "string"
+  },
+  "meta": {}
+}
+```
+
+<h3 id="get-der-for-service-point-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response|[EnergyDerDetailResponse](#schemacdr-energy-secondary-data-holder-apienergyderdetailresponse)|
+|4xx|[**Client Error**](https://tools.ietf.org/html/rfc7231#section-6.5)|The following error codes MUST be supported:<br/><ul class="error-code-list"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[404 - Unavailable Service Point](#error-404-unavailable-service-point)</li><li>[404 - Invalid Service Point](#error-404-invalid-service-point)</li></ul>|[ErrorListResponse](#schemacdr-energy-secondary-data-holder-apierrorlistresponse)|
+
+### Response Headers
+
+|Status|Header|Type|Format|Description|
+|---|---|---|---|---|
+|200|x-v|string||none|
+|200|x-fapi-interaction-id|string||none|
+|4xx|x-fapi-interaction-id|string||none|
+
+  
+    
+      <aside class="notice">
+To perform this operation, you must be authenticated and authorised with the following scopes:
+<a href="#authorisation-scopes">energy:electricity.der:read</a>
+</aside>
+
+    
+  
+
+## Get DER For Specific Service Points
+
+<a id="opIdlistDERForServicePoints"></a>
+
+> Code samples
+
+```http
+POST /secondary/energy/electricity/servicepoints/der HTTP/1.1
+
+Content-Type: application/json
+Accept: application/json
+x-v: string
+x-min-v: string
+x-fapi-interaction-id: string
+x-cds-arrangement: string
+
+```
+
+```javascript
+var headers = {
+  'Content-Type':'application/json',
+  'Accept':'application/json',
+  'x-v':'string',
+  'x-min-v':'string',
+  'x-fapi-interaction-id':'string',
+  'x-cds-arrangement':'string'
+
+};
+
+$.ajax({
+  url: '/secondary/energy/electricity/servicepoints/der',
+  method: 'post',
+
+  headers: headers,
+  success: function(data) {
+    console.log(JSON.stringify(data));
+  }
+})
+
+```
+
+`POST /secondary/energy/electricity/servicepoints/der`
+
+Obtain DER data for a specific set of service points
+
+> Body parameter
+
+```json
+{
+  "data": {
+    "servicePointIds": [
+      "string"
+    ]
+  },
+  "meta": {}
+}
+```
+
+###Endpoint Version
+|   |  |
+|---|--|
+|Version|**1**
+
+<h3 id="get-der-for-specific-service-points-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|page|query|number|optional|Page of results to request (standard pagination)|
+|page-size|query|number|optional|Page size to request.  Default is 25 (standard pagination)|
+|x-v|header|string|mandatory|Version of the API end point requested by the client. Must be set to a positive integer. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If the value of [x-min-v](#request-headers) is equal to or higher than the value of [x-v](#request-headers) then the [x-min-v](#request-headers) header should be treated as absent. If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable. See [HTTP Headers](#request-headers)|
+|x-min-v|header|string|optional|Minimum version of the API end point requested by the client. Must be set to a positive integer if provided. The data holder should respond with the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers). If all versions requested are not supported then the data holder must respond with a 406 Not Acceptable.|
+|x-fapi-interaction-id|header|string|optional|An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as a correlation id. If provided, the data holder must play back this value in the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID value is required to be provided in the response header to track the interaction.|
+|x-cds-arrangement|header|string|mandatory|A unique string representing a consent arrangement between a Data Recipient Software Product and Data Holder for a given consumer. The identifier MUST be unique per customer according to the definition of customer in the CDR Federation section of this profile. The x-cds-arrangement should contain the arrangement ID for the consent that the request is being made under and will be used for tracing and audit purposes. This field MUST be populated but AEMO MUST NOT seek to validate the consent associated with the arrangement|
+|body|body|[servicePointIdList](#schemacdr-energy-secondary-data-holder-apiservicepointidlist)|mandatory|Request payload containing list of specific Service Points to obtain data for|
+|» data|body|object|mandatory|none|
+|»» servicePointIds|body|[string]|mandatory|Array of specific NMIs to obtain data for|
+|» meta|body|[Meta](#schemacdr-energy-secondary-data-holder-apimeta)|mandatory|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "derRecords": [
+      {
+        "servicePointId": "string",
+        "approvedCapacity": 0,
+        "availablePhasesCount": 0,
+        "installedPhasesCount": 0,
+        "islandableInstallation": "string",
+        "hasCentralProtectionControl": false,
+        "protectionMode": {
+          "exportLimitkva": 0,
+          "underFrequencyProtection": 0,
+          "underFrequencyProtectionDelay": 0,
+          "overFrequencyProtection": 0,
+          "overFrequencyProtectionDelay": 0,
+          "underVoltageProtection": 0,
+          "underVoltageProtectionDelay": 0,
+          "overVoltageProtection": 0,
+          "overVoltageProtectionDelay": 0,
+          "sustainedOverVoltage": 0,
+          "sustainedOverVoltageDelay": 0,
+          "frequencyRateOfChange": 0,
+          "voltageVectorShift": 0,
+          "interTripScheme": "string",
+          "neutralVoltageDisplacement": 0
+        },
+        "acConnections": [
+          {
+            "connectionIdentifier": 0,
+            "count": "string",
+            "equipmentType": "INVERTER",
+            "manufacturerName": "string",
+            "inverterSeries": "string",
+            "inverterModelNumber": "string",
+            "commissioningDate": "string",
+            "status": "ACTIVE",
+            "inverterDeviceCapacity": 0,
+            "derDevices": [
+              {
+                "deviceIdentifier": 0,
+                "count": 0,
+                "manufacturer": "string",
+                "modelNumber": "string",
+                "status": "ACTIVE",
+                "type": "FOSSIL",
+                "subtype": "string",
+                "nominalRatedCapacity": 0,
+                "nominalStorageCapacity": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "self": "string",
+    "first": "string",
+    "prev": "string",
+    "next": "string",
+    "last": "string"
+  },
+  "meta": {
+    "totalRecords": 0,
+    "totalPages": 0
+  }
+}
+```
+
+<h3 id="get-der-for-specific-service-points-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response|[EnergyDerListResponse](#schemacdr-energy-secondary-data-holder-apienergyderlistresponse)|
+|4xx|[**Client Error**](https://tools.ietf.org/html/rfc7231#section-6.5)|The following error codes MUST be supported:<br/><ul class="error-code-list"><li>[400 - Invalid Field](#error-400-field-invalid)</li><li>[400 - Invalid Page Size](#error-400-field-invalid-page-size)</li><li>[400 - Invalid Version](#error-400-header-invalid-version)</li><li>[406 - Unsupported Version](#error-406-header-unsupported-version)</li><li>[422 - Invalid Page](#error-422-field-invalid-page)</li><li>[422 - Unavailable Service Point](#error-422-unavailable-service-point)</li><li>[422 - Invalid Service Point](#error-422-invalid-service-point)</li></ul>|[ErrorListResponse](#schemacdr-energy-secondary-data-holder-apierrorlistresponse)|
+
+### Response Headers
+
+|Status|Header|Type|Format|Description|
+|---|---|---|---|---|
+|200|x-v|string||none|
+|200|x-fapi-interaction-id|string||none|
+|4xx|x-fapi-interaction-id|string||none|
+
+  
+    
+      <aside class="notice">
+To perform this operation, you must be authenticated and authorised with the following scopes:
+<a href="#authorisation-scopes">energy:electricity.der:read</a>
+</aside>
+
+    
+  
+
+<h2 class="schema-heading" id="cdr-energy-secondary-data-holder-api-schemas">Schemas</h2>
+<a class="schema-link" id="cdr-energy-secondary-data-holder-api-schemas"></a>
+
+<h3 class="schema-toc" id="tocSenergyservicepointlistresponse">EnergyServicePointListResponse</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyservicepointlistresponse"></a>
+
+```json
+{
+  "data": {
+    "servicePoints": [
+      {
+        "servicePointId": "string",
+        "nationalMeteringId": "string",
+        "servicePointClassification": "EXTERNAL_PROFILE",
+        "servicePointStatus": "ACTIVE",
+        "jurisdictionCode": "ALL",
+        "isGenerator": true,
+        "validFromDate": "string",
+        "lastUpdateDateTime": "string",
+        "consumerProfile": {
+          "classification": "BUSINESS",
+          "threshold": "LOW"
+        }
+      }
+    ]
+  },
+  "links": {
+    "self": "string",
+    "first": "string",
+    "prev": "string",
+    "next": "string",
+    "last": "string"
+  },
+  "meta": {
+    "totalRecords": 0,
+    "totalPages": 0
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|data|object|mandatory|none|
+|» servicePoints|[[EnergyServicePoint](#schemacdr-energy-secondary-data-holder-apienergyservicepoint)]|mandatory|none|
+|links|[LinksPaginated](#schemacdr-energy-secondary-data-holder-apilinkspaginated)|mandatory|none|
+|meta|[MetaPaginated](#schemacdr-energy-secondary-data-holder-apimetapaginated)|mandatory|none|
+
+<h3 class="schema-toc" id="tocSenergyservicepointdetailresponse">EnergyServicePointDetailResponse</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyservicepointdetailresponse"></a>
+
+```json
+{
+  "data": {
+    "servicePointId": "string",
+    "nationalMeteringId": "string",
+    "servicePointClassification": "EXTERNAL_PROFILE",
+    "servicePointStatus": "ACTIVE",
+    "jurisdictionCode": "ALL",
+    "isGenerator": true,
+    "validFromDate": "string",
+    "lastUpdateDateTime": "string",
+    "consumerProfile": {
+      "classification": "BUSINESS",
+      "threshold": "LOW"
+    },
+    "distributionLossFactor": {
+      "code": "string",
+      "description": "string",
+      "lossValue": "string"
+    },
+    "relatedParticipants": [
+      {
+        "party": "string",
+        "role": "FRMP"
+      }
+    ],
+    "location": {
+      "addressUType": "simple",
+      "simple": {
+        "mailingName": "string",
+        "addressLine1": "string",
+        "addressLine2": "string",
+        "addressLine3": "string",
+        "postcode": "string",
+        "city": "string",
+        "state": "string",
+        "country": "AUS"
+      },
+      "paf": {
+        "dpid": "string",
+        "thoroughfareNumber1": 0,
+        "thoroughfareNumber1Suffix": "string",
+        "thoroughfareNumber2": 0,
+        "thoroughfareNumber2Suffix": "string",
+        "flatUnitType": "string",
+        "flatUnitNumber": "string",
+        "floorLevelType": "string",
+        "floorLevelNumber": "string",
+        "lotNumber": "string",
+        "buildingName1": "string",
+        "buildingName2": "string",
+        "streetName": "string",
+        "streetType": "string",
+        "streetSuffix": "string",
+        "postalDeliveryType": "string",
+        "postalDeliveryNumber": 0,
+        "postalDeliveryNumberPrefix": "string",
+        "postalDeliveryNumberSuffix": "string",
+        "localityName": "string",
+        "postcode": "string",
+        "state": "string"
+      }
+    },
+    "meters": {
+      "meterId": "string",
+      "specifications": {
+        "status": "CURRENT",
+        "installationType": "BASIC",
+        "manufacturer": "string",
+        "model": "string",
+        "readType": "string",
+        "nextScheduledReadDate": "string"
+      },
+      "registers": {
+        "registerId": "string",
+        "registerSuffix": "string",
+        "averagedDailyLoad": 0,
+        "registerConsumptionType": "INTERVAL",
+        "networkTariffCode": "string",
+        "unitOfMeasure": "string",
+        "timeOfDay": "ALLDAY",
+        "multiplier": 0,
+        "controlledLoad": true,
+        "consumptionType": "ACTUAL"
+      }
+    }
+  },
+  "links": {
+    "self": "string"
+  },
+  "meta": {}
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|data|[EnergyServicePointDetail](#schemacdr-energy-secondary-data-holder-apienergyservicepointdetail)|mandatory|none|
+|links|[Links](#schemacdr-energy-secondary-data-holder-apilinks)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-secondary-data-holder-apimeta)|mandatory|none|
+
+<h3 class="schema-toc" id="tocSenergyusagelistresponse">EnergyUsageListResponse</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyusagelistresponse"></a>
+
+```json
+{
+  "data": {
+    "reads": [
+      {
+        "servicePointId": "string",
+        "registerId": "string",
+        "registerSuffix": "string",
+        "meterID": "string",
+        "controlledLoad": true,
+        "readStartDate": "string",
+        "readEndDate": "string",
+        "unitOfMeasure": "string",
+        "readUType": "basicRead",
+        "basicRead": {
+          "quality": "ACTUAL",
+          "value": 0
+        },
+        "intervalRead": {
+          "readIntervalLength": "string",
+          "aggregateValue": 0,
+          "intervalReads": [
+            {
+              "quality": "ACTUAL",
+              "value": 0
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "links": {
+    "self": "string",
+    "first": "string",
+    "prev": "string",
+    "next": "string",
+    "last": "string"
+  },
+  "meta": {
+    "totalRecords": 0,
+    "totalPages": 0
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|data|object|mandatory|none|
+|» reads|[[EnergyUsageRead](#schemacdr-energy-secondary-data-holder-apienergyusageread)]|mandatory|Array of meter reads|
+|links|[LinksPaginated](#schemacdr-energy-secondary-data-holder-apilinkspaginated)|mandatory|none|
+|meta|[MetaPaginated](#schemacdr-energy-secondary-data-holder-apimetapaginated)|mandatory|none|
+
+<h3 class="schema-toc" id="tocSenergyderlistresponse">EnergyDerListResponse</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyderlistresponse"></a>
+
+```json
+{
+  "data": {
+    "derRecords": [
+      {
+        "servicePointId": "string",
+        "approvedCapacity": 0,
+        "availablePhasesCount": 0,
+        "installedPhasesCount": 0,
+        "islandableInstallation": "string",
+        "hasCentralProtectionControl": false,
+        "protectionMode": {
+          "exportLimitkva": 0,
+          "underFrequencyProtection": 0,
+          "underFrequencyProtectionDelay": 0,
+          "overFrequencyProtection": 0,
+          "overFrequencyProtectionDelay": 0,
+          "underVoltageProtection": 0,
+          "underVoltageProtectionDelay": 0,
+          "overVoltageProtection": 0,
+          "overVoltageProtectionDelay": 0,
+          "sustainedOverVoltage": 0,
+          "sustainedOverVoltageDelay": 0,
+          "frequencyRateOfChange": 0,
+          "voltageVectorShift": 0,
+          "interTripScheme": "string",
+          "neutralVoltageDisplacement": 0
+        },
+        "acConnections": [
+          {
+            "connectionIdentifier": 0,
+            "count": "string",
+            "equipmentType": "INVERTER",
+            "manufacturerName": "string",
+            "inverterSeries": "string",
+            "inverterModelNumber": "string",
+            "commissioningDate": "string",
+            "status": "ACTIVE",
+            "inverterDeviceCapacity": 0,
+            "derDevices": [
+              {
+                "deviceIdentifier": 0,
+                "count": 0,
+                "manufacturer": "string",
+                "modelNumber": "string",
+                "status": "ACTIVE",
+                "type": "FOSSIL",
+                "subtype": "string",
+                "nominalRatedCapacity": 0,
+                "nominalStorageCapacity": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "self": "string",
+    "first": "string",
+    "prev": "string",
+    "next": "string",
+    "last": "string"
+  },
+  "meta": {
+    "totalRecords": 0,
+    "totalPages": 0
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|data|object|mandatory|none|
+|» derRecords|[[EnergyDerRecord](#schemacdr-energy-secondary-data-holder-apienergyderrecord)]|mandatory|Array of meter reads|
+|links|[LinksPaginated](#schemacdr-energy-secondary-data-holder-apilinkspaginated)|mandatory|none|
+|meta|[MetaPaginated](#schemacdr-energy-secondary-data-holder-apimetapaginated)|mandatory|none|
+
+<h3 class="schema-toc" id="tocSenergyderdetailresponse">EnergyDerDetailResponse</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyderdetailresponse"></a>
+
+```json
+{
+  "data": {
+    "servicePointId": "string",
+    "approvedCapacity": 0,
+    "availablePhasesCount": 0,
+    "installedPhasesCount": 0,
+    "islandableInstallation": "string",
+    "hasCentralProtectionControl": false,
+    "protectionMode": {
+      "exportLimitkva": 0,
+      "underFrequencyProtection": 0,
+      "underFrequencyProtectionDelay": 0,
+      "overFrequencyProtection": 0,
+      "overFrequencyProtectionDelay": 0,
+      "underVoltageProtection": 0,
+      "underVoltageProtectionDelay": 0,
+      "overVoltageProtection": 0,
+      "overVoltageProtectionDelay": 0,
+      "sustainedOverVoltage": 0,
+      "sustainedOverVoltageDelay": 0,
+      "frequencyRateOfChange": 0,
+      "voltageVectorShift": 0,
+      "interTripScheme": "string",
+      "neutralVoltageDisplacement": 0
+    },
+    "acConnections": [
+      {
+        "connectionIdentifier": 0,
+        "count": "string",
+        "equipmentType": "INVERTER",
+        "manufacturerName": "string",
+        "inverterSeries": "string",
+        "inverterModelNumber": "string",
+        "commissioningDate": "string",
+        "status": "ACTIVE",
+        "inverterDeviceCapacity": 0,
+        "derDevices": [
+          {
+            "deviceIdentifier": 0,
+            "count": 0,
+            "manufacturer": "string",
+            "modelNumber": "string",
+            "status": "ACTIVE",
+            "type": "FOSSIL",
+            "subtype": "string",
+            "nominalRatedCapacity": 0,
+            "nominalStorageCapacity": 0
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "self": "string"
+  },
+  "meta": {}
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|data|[EnergyDerRecord](#schemacdr-energy-secondary-data-holder-apienergyderrecord)|mandatory|none|
+|links|[Links](#schemacdr-energy-secondary-data-holder-apilinks)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-secondary-data-holder-apimeta)|mandatory|none|
+
+<h3 class="schema-toc" id="tocSerrorlistresponse">ErrorListResponse</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apierrorlistresponse"></a>
+
+```json
+{
+  "errors": [
+    {
+      "code": "string",
+      "title": "string",
+      "detail": "string",
+      "meta": {
+        "urn": "string"
+      }
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|errors|[object]|mandatory|none|
+|» code|string|mandatory|The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.|
+|» title|string|mandatory|A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.|
+|» detail|string|mandatory|A human-readable explanation specific to this occurrence of the problem.|
+|» meta|object|optional|Additional data for customised error codes|
+|»» urn|string|conditional|The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.|
+
+<h3 class="schema-toc" id="tocSenergyservicepoint">EnergyServicePoint</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyservicepoint"></a>
+
+```json
+{
+  "servicePointId": "string",
+  "nationalMeteringId": "string",
+  "servicePointClassification": "EXTERNAL_PROFILE",
+  "servicePointStatus": "ACTIVE",
+  "jurisdictionCode": "ALL",
+  "isGenerator": true,
+  "validFromDate": "string",
+  "lastUpdateDateTime": "string",
+  "consumerProfile": {
+    "classification": "BUSINESS",
+    "threshold": "LOW"
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|servicePointId|string|mandatory|The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.|
+|nationalMeteringId|string|mandatory|The independent ID of the service point, known in the industry as the NMI|
+|servicePointClassification|string|mandatory|The classification of the service point as defined in MSATS procedures|
+|servicePointStatus|string|mandatory|Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>|
+|jurisdictionCode|string|mandatory|Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>|
+|isGenerator|boolean|optional|This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer|
+|validFromDate|[DateString](#common-field-types)|mandatory|The start date from which this service point first became valid|
+|lastUpdateDateTime|[DateTimeString](#common-field-types)|mandatory|The date and time that the information for this service point was modified|
+|consumerProfile|object|optional|none|
+|» classification|string|optional|A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments|
+|» threshold|any|optional|A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|servicePointClassification|EXTERNAL_PROFILE|
+|servicePointClassification|GENERATOR|
+|servicePointClassification|LARGE|
+|servicePointClassification|SMALL|
+|servicePointClassification|WHOLESALE|
+|servicePointClassification|NON_CONTEST_UNMETERED_LOAD|
+|servicePointClassification|NON_REGISTERED_EMBEDDED_GENERATOR|
+|servicePointClassification|DISTRIBUTION_WHOLESALE|
+|servicePointStatus|ACTIVE|
+|servicePointStatus|DE_ENERGISED|
+|servicePointStatus|EXTINCT|
+|servicePointStatus|GREENFIELD|
+|servicePointStatus|OFF_MARKET|
+|jurisdictionCode|ALL|
+|jurisdictionCode|ACT|
+|jurisdictionCode|NEM|
+|jurisdictionCode|NSW|
+|jurisdictionCode|QLD|
+|jurisdictionCode|SA|
+|jurisdictionCode|TAS|
+|jurisdictionCode|VIC|
+|classification|BUSINESS|
+|classification|RESIDENTIAL|
+|threshold|LOW|
+|threshold|MEDIUM|
+|threshold|HIGH|
+
+<h3 class="schema-toc" id="tocSenergyservicepointdetail">EnergyServicePointDetail</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyservicepointdetail"></a>
+
+```json
+{
+  "servicePointId": "string",
+  "nationalMeteringId": "string",
+  "servicePointClassification": "EXTERNAL_PROFILE",
+  "servicePointStatus": "ACTIVE",
+  "jurisdictionCode": "ALL",
+  "isGenerator": true,
+  "validFromDate": "string",
+  "lastUpdateDateTime": "string",
+  "consumerProfile": {
+    "classification": "BUSINESS",
+    "threshold": "LOW"
+  },
+  "distributionLossFactor": {
+    "code": "string",
+    "description": "string",
+    "lossValue": "string"
+  },
+  "relatedParticipants": [
+    {
+      "party": "string",
+      "role": "FRMP"
+    }
+  ],
+  "location": {
+    "addressUType": "simple",
+    "simple": {
+      "mailingName": "string",
+      "addressLine1": "string",
+      "addressLine2": "string",
+      "addressLine3": "string",
+      "postcode": "string",
+      "city": "string",
+      "state": "string",
+      "country": "AUS"
+    },
+    "paf": {
+      "dpid": "string",
+      "thoroughfareNumber1": 0,
+      "thoroughfareNumber1Suffix": "string",
+      "thoroughfareNumber2": 0,
+      "thoroughfareNumber2Suffix": "string",
+      "flatUnitType": "string",
+      "flatUnitNumber": "string",
+      "floorLevelType": "string",
+      "floorLevelNumber": "string",
+      "lotNumber": "string",
+      "buildingName1": "string",
+      "buildingName2": "string",
+      "streetName": "string",
+      "streetType": "string",
+      "streetSuffix": "string",
+      "postalDeliveryType": "string",
+      "postalDeliveryNumber": 0,
+      "postalDeliveryNumberPrefix": "string",
+      "postalDeliveryNumberSuffix": "string",
+      "localityName": "string",
+      "postcode": "string",
+      "state": "string"
+    }
+  },
+  "meters": {
+    "meterId": "string",
+    "specifications": {
+      "status": "CURRENT",
+      "installationType": "BASIC",
+      "manufacturer": "string",
+      "model": "string",
+      "readType": "string",
+      "nextScheduledReadDate": "string"
+    },
+    "registers": {
+      "registerId": "string",
+      "registerSuffix": "string",
+      "averagedDailyLoad": 0,
+      "registerConsumptionType": "INTERVAL",
+      "networkTariffCode": "string",
+      "unitOfMeasure": "string",
+      "timeOfDay": "ALLDAY",
+      "multiplier": 0,
+      "controlledLoad": true,
+      "consumptionType": "ACTUAL"
+    }
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|servicePointId|string|mandatory|The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.|
+|nationalMeteringId|string|mandatory|The independent ID of the service point, known in the industry as the NMI|
+|servicePointClassification|string|mandatory|The classification of the service point as defined in MSATS procedures|
+|servicePointStatus|string|mandatory|Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>|
+|jurisdictionCode|string|mandatory|Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>|
+|isGenerator|boolean|optional|This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer|
+|validFromDate|[DateString](#common-field-types)|mandatory|The start date from which this service point first became valid|
+|lastUpdateDateTime|[DateTimeString](#common-field-types)|mandatory|The date and time that the information for this service point was modified|
+|consumerProfile|object|optional|none|
+|» classification|string|optional|A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments|
+|» threshold|any|optional|A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>|
+|distributionLossFactor|object|mandatory|none|
+|» code|string|mandatory|A code used to identify data loss factor for the service point values.  Refer to AEMO distribution loss factor documents for each financial year to interpret|
+|» description|string|mandatory|Description of the data loss factor code and value|
+|» lossValue|string|mandatory|The value associated with the loss factor code|
+|relatedParticipants|[object]|mandatory|none|
+|» party|string|mandatory|The name of the party/orginsation related to this service point|
+|» role|string|mandatory|The role performed by this participant in relation to the service point. Note the details of enumeration values below: <ul><li>**FRMP** - Financially Responsible Market Participant</li><li>**LNSP** - Local Network Service Provider or Embedded Network Manager for child connection points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary Service Provider and note that where it is not relevant for a NMI it will not be included</li></ul>|
+|location|object|mandatory|none|
+|» addressUType|string|mandatory|The type of address object present|
+|» simple|object|conditional|The address of the service point.  Mandatory if addressUType is set to simple|
+|»» mailingName|string|optional|Name of the individual or business formatted for inclusion in an address used for physical mail|
+|»» addressLine1|string|mandatory|First line of the standard address object|
+|»» addressLine2|string|optional|Second line of the standard address object|
+|»» addressLine3|string|optional|Third line of the standard address object|
+|»» postcode|string|conditional|Mandatory for Australian addresses|
+|»» city|string|mandatory|Name of the city or locality|
+|»» state|string|mandatory|Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT|
+|»» country|[ExternalRef](#common-field-types)|optional|A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.|
+|» paf|object|conditional|The address of the service point.  Mandatory if addressUType is set to paf. Formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)|
+|»» dpid|string|optional|Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier|
+|»» thoroughfareNumber1|[PositiveInteger](#common-field-types)|optional|Thoroughfare number for a property (first number in a property ranged address)|
+|»» thoroughfareNumber1Suffix|string|optional|Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated|
+|»» thoroughfareNumber2|[PositiveInteger](#common-field-types)|optional|Second thoroughfare number (only used if the property has a ranged address eg 23-25)|
+|»» thoroughfareNumber2Suffix|string|optional|Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated|
+|»» flatUnitType|string|optional|Type of flat or unit for the address|
+|»» flatUnitNumber|string|optional|Unit number (including suffix, if applicable)|
+|»» floorLevelType|string|optional|Type of floor or level for the address|
+|»» floorLevelNumber|string|optional|Floor or level number (including alpha characters)|
+|»» lotNumber|string|optional|Allotment number for the address|
+|»» buildingName1|string|optional|Building/Property name 1|
+|»» buildingName2|string|optional|Building/Property name 2|
+|»» streetName|string|optional|The name of the street|
+|»» streetType|string|optional|The street type. Valid enumeration defined by Australia Post PAF code file|
+|»» streetSuffix|string|optional|The street type suffix. Valid enumeration defined by Australia Post PAF code file|
+|»» postalDeliveryType|string|optional|Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file|
+|»» postalDeliveryNumber|[PositiveInteger](#common-field-types)|optional|Postal delivery number if the address is a postal delivery type|
+|»» postalDeliveryNumberPrefix|string|optional|Postal delivery number prefix related to the postal delivery number|
+|»» postalDeliveryNumberSuffix|string|optional|Postal delivery number suffix related to the postal delivery number|
+|»» localityName|string|mandatory|Full name of locality|
+|»» postcode|string|mandatory|Postcode for the locality|
+|»» state|string|mandatory|State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT|
+|» meters|object|mandatory|none|
+|»» meterId|string|mandatory|The meter ID uniquely identifies a meter for a given service point.  It is unique in the context of the service point.  It is not globally unique|
+|»» specifications|object|mandatory|Technical characteristics of the meter|
+|»»» status|string|mandatory|A code to denote the status of the meter. Note the details of enumeration values below: <ul><li>**CURRENT** -Applies when a meter is current and not disconnected</li><li>**DISCONNECTED** - Applies when a meter is present but has been remotely disconnected</li></ul>|
+|»»» installationType|string|mandatory|The metering Installation type code indicates whether the metering installation has to be manually read. Note the details of enumeration values below: <ul><li>**BASIC** - Accumulation Meter – Type 6</li><li>**COMMS1** - Interval Meter with communications – Type 1</li><li>**COMMS2** - Interval Meter with communications – Type 2</li><li>**COMMS3** - Interval Meter with communications – Type 3</li><li>**COMMS4** - Interval Meter with communications – Type 4</li><li>**COMMS4C** - CT connected metering installation that meets the minimum services specifications</li><li>**COMMS4D** - Whole current metering installation that meets the minimum services specifications</li><li>**MRAM** - Small customer metering installation – Type 4A</li><li>**MRIM** - Manually Read Interval Meter – Type 5</li><li>**UMCP** - Unmetered Supply – Type 7</li><li>**VICAMI** - A relevant metering installation as defined in clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load - Introduced as part of Global Settlement</li></ul>|
+|»»» manufacturer|string|optional|Free text field to identify the manufacturer of the installed meter|
+|»»» model|string|optional|Free text field to identify the meter manufacturer’s designation for the meter model|
+|»»» readType|string|optional|Code to denote the method and frequency of Meter Reading. The value is formatted as follows: <ul><li>First Character = Remote (R) or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 = Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional Fourth Character = to identify what interval length the meter is capable of reading. This includes five, 15 and 30 minute granularity as the following: A – 5 minute B – 15 minute C – 30 minute D – Cannot convert to 5 minute (i.e. due to metering installation de-energised) M - Manually Read Accumulation Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li> <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li> <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>|
+|»»» nextScheduledReadDate|[DateString](#common-field-types)|optional|This date is the next scheduled meter read date (NSRD) if a manual Meter Reading is required|
+|»» registers|object|mandatory|Usage data registers available from the meter|
+|»»» registerId|string|mandatory|Unique identifier of the register within this service point.  Is not globally unique|
+|»»» registerSuffix|string|mandatory|Register suffix of the meter register where the meter reads are obtained|
+|»»» averagedDailyLoad|number|optional|The energy delivered through a connection point or metering point over an extended period normalised to a 'per day' basis (kWh). This value is calculated annually.|
+|»»» registerConsumptionType|string|mandatory|Indicates the consumption type of register|
+|»»» networkTariffCode|string|optional|The Network Tariff Code is a free text field containing a code supplied and published by the local network service provider|
+|»»» unitOfMeasure|string|optional|The unit of measure for data held in this register|
+|»»» timeOfDay|string|optional|Code to identify the time validity of register contents|
+|»»» multiplier|number|optional|Multiplier required to take a register value and turn it into a value representing billable energy|
+|»»» controlledLoad|boolean|optional|Indicates whether the energy recorded by this register is created under a Controlled Load regime. ControlledLoad field will have 'No' if register does not relate to a Controlled Load.  If the register relates to a Controlled Load, it should contain a description of the Controlled Load regime. ControlledLoad field will have 'No' if register does not relate to a Controlled Load, “Yes” if register relates to a Controlled Load If absent the status is unknown.|
+|»»» consumptionType|string|optional|Actual/Subtractive Indicator. Note the details of enumeration values below: <ul><li>**ACTUAL** implies volume of energy actually metered between two dates</li><li>**CUMULATIVE** indicates a meter reading for a specific date. A second Meter Reading is required to determine the consumption between those two Meter Reading dates</li></ul>|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|servicePointClassification|EXTERNAL_PROFILE|
+|servicePointClassification|GENERATOR|
+|servicePointClassification|LARGE|
+|servicePointClassification|SMALL|
+|servicePointClassification|WHOLESALE|
+|servicePointClassification|NON_CONTEST_UNMETERED_LOAD|
+|servicePointClassification|NON_REGISTERED_EMBEDDED_GENERATOR|
+|servicePointClassification|DISTRIBUTION_WHOLESALE|
+|servicePointStatus|ACTIVE|
+|servicePointStatus|DE_ENERGISED|
+|servicePointStatus|EXTINCT|
+|servicePointStatus|GREENFIELD|
+|servicePointStatus|OFF_MARKET|
+|jurisdictionCode|ALL|
+|jurisdictionCode|ACT|
+|jurisdictionCode|NEM|
+|jurisdictionCode|NSW|
+|jurisdictionCode|QLD|
+|jurisdictionCode|SA|
+|jurisdictionCode|TAS|
+|jurisdictionCode|VIC|
+|classification|BUSINESS|
+|classification|RESIDENTIAL|
+|threshold|LOW|
+|threshold|MEDIUM|
+|threshold|HIGH|
+|role|FRMP|
+|role|LNSP|
+|role|DRSP|
+|addressUType|simple|
+|addressUType|paf|
+|status|CURRENT|
+|status|DISCONNECTED|
+|installationType|BASIC|
+|installationType|COMMS1|
+|installationType|COMMS2|
+|installationType|COMMS3|
+|installationType|COMMS4|
+|installationType|COMMS4C|
+|installationType|COMMS4D|
+|installationType|MRAM|
+|installationType|MRIM|
+|installationType|PROF|
+|installationType|SAMPLE|
+|installationType|UMCP|
+|installationType|VICAMI|
+|installationType|NCOLNUML|
+|registerConsumptionType|INTERVAL|
+|registerConsumptionType|BASIC|
+|registerConsumptionType|PROFILE_DATA|
+|registerConsumptionType|ACTIVE_IMPORT|
+|registerConsumptionType|ACTIVE|
+|registerConsumptionType|REACTIVE_IMPORT|
+|registerConsumptionType|REACTIVE|
+|timeOfDay|ALLDAY|
+|timeOfDay|INTERVAL|
+|timeOfDay|PEAK|
+|timeOfDay|BUSINESS|
+|timeOfDay|SHOULDER|
+|timeOfDay|EVENING|
+|timeOfDay|OFFPEAK|
+|timeOfDay|CONTROLLED|
+|timeOfDay|DEMAND|
+|consumptionType|ACTUAL|
+|consumptionType|CUMULATIVE|
+
+<h3 class="schema-toc" id="tocSenergyusageread">EnergyUsageRead</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyusageread"></a>
+
+```json
+{
+  "servicePointId": "string",
+  "registerId": "string",
+  "registerSuffix": "string",
+  "meterID": "string",
+  "controlledLoad": true,
+  "readStartDate": "string",
+  "readEndDate": "string",
+  "unitOfMeasure": "string",
+  "readUType": "basicRead",
+  "basicRead": {
+    "quality": "ACTUAL",
+    "value": 0
+  },
+  "intervalRead": {
+    "readIntervalLength": "string",
+    "aggregateValue": 0,
+    "intervalReads": [
+      {
+        "quality": "ACTUAL",
+        "value": 0
+      }
+    ]
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|servicePointId|string|mandatory|The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.|
+|registerId|string|optional|Register ID of the meter register where the meter reads are obtained|
+|registerSuffix|string|mandatory|Register suffix of the meter register where the meter reads are obtained|
+|meterID|string|optional|Meter id/serial number as it appears in customer’s bill. ID permanence rules do not apply.|
+|controlledLoad|boolean|optional|Indicates whether the energy recorded by this register is created under a Controlled Load regime. ControlledLoad field will have 'No if register does not relate to a Controlled Load, “Yes” if register relates to a Controlled Load If absent the status is unknown.|
+|readStartDate|[DateString](#common-field-types)|mandatory|Date time when the meter reads start|
+|readEndDate|[DateString](#common-field-types)|optional|Date time when the meter reads end.  If absent then assumed to be equal to readStartDate.  In this case the entry represents data for a single date specified by readStartDate|
+|unitOfMeasure|string|optional|Unit of measure of the meter reads. Refer to Appendix B of <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF Specification NEM12 NEM13 v2.1</a> for a list of possible values|
+|readUType|string|mandatory|Specify the type of the meter read data|
+|basicRead|object|conditional|Mandatory if readUType is set to basicRead|
+|» quality|string|optional|The quality of the read taken.  If absent then assumed to be ACTUAL|
+|» value|number|mandatory|Meter read value.  If positive then it means consumption, if negative it means export|
+|intervalRead|object|conditional|Mandatory if readUType is set to intervalRead|
+|» readIntervalLength|[PositiveInteger](#common-field-types)|mandatory|Read interval length in minutes|
+|» aggregateValue|number|mandatory|The aggregate sum of the interval read values. If positive then it means net consumption, if negative it means net export|
+|» intervalReads|[object]|mandatory|Array of reads with each element indicating the read for the interval specified by readIntervalLength beginning at midnight of readStartDate (for example 00:00 to 00:30 would be the first reading in a 30 minute Interval)|
+|»» quality|string|optional|The quality of the read taken.  If absent then assumed to be ACTUAL|
+|»» value|number|mandatory|Interval value.  If positive then it means consumption, if negative it means export|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|readUType|basicRead|
+|readUType|intervalRead|
+|quality|ACTUAL|
+|quality|SUBSTITUTE|
+|quality|FINAL_SUBSTITUTE|
+|quality|ACTUAL|
+|quality|SUBSTITUTE|
+|quality|FINAL_SUBSTITUTE|
+
+<h3 class="schema-toc" id="tocSenergyderrecord">EnergyDerRecord</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apienergyderrecord"></a>
+
+```json
+{
+  "servicePointId": "string",
+  "approvedCapacity": 0,
+  "availablePhasesCount": 0,
+  "installedPhasesCount": 0,
+  "islandableInstallation": "string",
+  "hasCentralProtectionControl": false,
+  "protectionMode": {
+    "exportLimitkva": 0,
+    "underFrequencyProtection": 0,
+    "underFrequencyProtectionDelay": 0,
+    "overFrequencyProtection": 0,
+    "overFrequencyProtectionDelay": 0,
+    "underVoltageProtection": 0,
+    "underVoltageProtectionDelay": 0,
+    "overVoltageProtection": 0,
+    "overVoltageProtectionDelay": 0,
+    "sustainedOverVoltage": 0,
+    "sustainedOverVoltageDelay": 0,
+    "frequencyRateOfChange": 0,
+    "voltageVectorShift": 0,
+    "interTripScheme": "string",
+    "neutralVoltageDisplacement": 0
+  },
+  "acConnections": [
+    {
+      "connectionIdentifier": 0,
+      "count": "string",
+      "equipmentType": "INVERTER",
+      "manufacturerName": "string",
+      "inverterSeries": "string",
+      "inverterModelNumber": "string",
+      "commissioningDate": "string",
+      "status": "ACTIVE",
+      "inverterDeviceCapacity": 0,
+      "derDevices": [
+        {
+          "deviceIdentifier": 0,
+          "count": 0,
+          "manufacturer": "string",
+          "modelNumber": "string",
+          "status": "ACTIVE",
+          "type": "FOSSIL",
+          "subtype": "string",
+          "nominalRatedCapacity": 0,
+          "nominalStorageCapacity": 0
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|servicePointId|string|mandatory|The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.|
+|approvedCapacity|number|mandatory|Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA|
+|availablePhasesCount|number|mandatory|The number of phases available for the installation of DER|
+|installedPhasesCount|number|mandatory|The number of phases that DER is connected to|
+|islandableInstallation|string|mandatory|For identification of small generating units designed with the ability to operate in an islanded mode|
+|hasCentralProtectionControl|boolean|optional|For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false|
+|protectionMode|object|conditional|Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place|
+|» exportLimitkva|number|optional|Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit|
+|» underFrequencyProtection|number|optional|Protective function limit in Hz.|
+|» underFrequencyProtectionDelay|number|optional|Trip delay time in seconds.|
+|» overFrequencyProtection|number|optional|Protective function limit in Hz.|
+|» overFrequencyProtectionDelay|number|optional|Trip delay time in seconds.|
+|» underVoltageProtection|number|optional|Protective function limit in V.|
+|» underVoltageProtectionDelay|number|optional|Trip delay time in seconds.|
+|» overVoltageProtection|number|optional|Protective function limit in V.|
+|» overVoltageProtectionDelay|number|optional|Trip delay time in seconds.|
+|» sustainedOverVoltage|number|optional|Sustained over voltage.|
+|» sustainedOverVoltageDelay|number|optional|Trip delay time in seconds.|
+|» frequencyRateOfChange|number|optional|Rate of change of frequency trip point (Hz/s).|
+|» voltageVectorShift|number|optional|Trip angle in degrees.|
+|» interTripScheme|string|optional|Description of the form of inter-trip (e.g. 'from local substation').|
+|» neutralVoltageDisplacement|number|optional|Trip voltage.|
+|acConnections|[object]|mandatory|none|
+|» connectionIdentifier|number|mandatory|AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards|
+|» count|[PositiveInteger](#common-field-types)|mandatory|Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes|
+|» equipmentType|string|optional|Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.|
+|» manufacturerName|string|conditional|The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER|
+|» inverterSeries|string|conditional|The inverter series. Mandatory if equipmentType is INVERTER|
+|» inverterModelNumber|string|conditional|The inverter model number. Mandatory if equipmentType is INVERTER|
+|» commissioningDate|[DateString](#common-field-types)|mandatory|The date that the DER installation is commissioned|
+|» status|string|mandatory|Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned|
+|» inverterDeviceCapacity|number|conditional|The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER|
+|» derDevices|[object]|mandatory|none|
+|»» deviceIdentifier|number|mandatory|Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards|
+|»» count|number|mandatory|Number of devices in the group of DER devices|
+|»» manufacturer|string|optional|The name of the device manufacturer. If absent then assumed to be “unknown”|
+|»» modelNumber|string|optional|The model number of the device. If absent then assumed to be “unknown”|
+|»» status|string|optional|Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned|
+|»» type|string|mandatory|Used to indicate the primary technology used in the DER device|
+|»» subtype|string|optional|Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”|
+|»» nominalRatedCapacity|number|mandatory|Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group|
+|»» nominalStorageCapacity|number|conditional|Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|equipmentType|INVERTER|
+|equipmentType|OTHER|
+|status|ACTIVE|
+|status|INACTIVE|
+|status|DECOMMISSIONED|
+|status|ACTIVE|
+|status|INACTIVE|
+|status|DECOMMISSIONED|
+|type|FOSSIL|
+|type|HYDRO|
+|type|WIND|
+|type|SOLAR_PV|
+|type|RENEWABLE|
+|type|GEOTHERMAL|
+|type|STORAGE|
+|type|OTHER|
+
+<h3 class="schema-toc" id="tocSlinks">Links</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apilinks"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|self|[URIString](#common-field-types)|mandatory|Fully qualified link that generated the current response document|
+
+<h3 class="schema-toc" id="tocSmeta">Meta</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apimeta"></a>
+
+```json
+{}
+
+```
+
+### Properties
+
+*None*
+
+<h3 class="schema-toc" id="tocSlinkspaginated">LinksPaginated</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apilinkspaginated"></a>
+
+```json
+{
+  "self": "string",
+  "first": "string",
+  "prev": "string",
+  "next": "string",
+  "last": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|self|[URIString](#common-field-types)|mandatory|Fully qualified link that generated the current response document|
+|first|[URIString](#common-field-types)|conditional|URI to the first page of this set. Mandatory if this response is not the first page|
+|prev|[URIString](#common-field-types)|conditional|URI to the previous page of this set. Mandatory if this response is not the first page|
+|next|[URIString](#common-field-types)|conditional|URI to the next page of this set. Mandatory if this response is not the last page|
+|last|[URIString](#common-field-types)|conditional|URI to the last page of this set. Mandatory if this response is not the last page|
+
+<h3 class="schema-toc" id="tocSmetapaginated">MetaPaginated</h3>
+
+<a id="schemacdr-energy-secondary-data-holder-apimetapaginated"></a>
+
+```json
+{
+  "totalRecords": 0,
+  "totalPages": 0
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|totalRecords|[NaturalNumber](#common-field-types)|mandatory|The total number of records in the full set. See [pagination](#pagination).|
+|totalPages|[NaturalNumber](#common-field-types)|mandatory|The total number of pages in the full set. See [pagination](#pagination).|
+

--- a/swagger-gen/create_markdown.sh
+++ b/swagger-gen/create_markdown.sh
@@ -21,6 +21,13 @@ echo "*** Generate cds_energy.md"
 
 diff -w cds_energy.md ../slate/source/includes/cds_energy.md > diff_energy.txt
 
+echo "*** Generate cds_energy_sdh.md"
+{
+  node ./widdershins-cdr/widdershins.js --environment ./widdershins-cdr/cdr_widdershins.json --search false --language_tabs 'http:HTTP' 'javascript:Javascript' --summary api/cds_energy_sdh.json -o cds_energy_sdh.md >> create-markdown-log.txt
+} >> create-markdown-log.txt 2>&1
+
+diff -w cds_energy_sdh.md ../slate/source/includes/cds_energy_sdh.md > diff_energy_sdh.txt
+
 
 echo "*** Generate cds_common.md"
 {

--- a/swagger-gen/generate_json.sh
+++ b/swagger-gen/generate_json.sh
@@ -3,6 +3,7 @@ set -o errexit #abort if any command fails
 # format <filename> <cli_output_format> <ext> <output-dir>
 ./swagger_generate.sh api/cds_banking.json swagger json ../slate/source/includes/swagger
 ./oas_generate.sh api/cds_energy.json openapi json ../slate/source/includes/swagger
+./oas_generate.sh api/cds_energy_sdh.json openapi json ../slate/source/includes/swagger
 ./swagger_generate.sh api/cds_common.json swagger json ../slate/source/includes/swagger
 ./swagger_generate.sh api/cds_admin.json swagger json ../slate/source/includes/swagger
 ./swagger_generate.sh api/cds_register.json swagger json ../slate/source/includes/swagger

--- a/swagger-gen/generate_yaml.sh
+++ b/swagger-gen/generate_yaml.sh
@@ -3,6 +3,7 @@ set -o errexit #abort if any command fails
 # format <filename> <cli_output_format> <ext> <output-dir>
 ./swagger_generate.sh api/cds_banking.json swagger-yaml yaml ../slate/source/includes/swagger
 ./oas_generate.sh api/cds_energy.json openapi-yaml yaml ../slate/source/includes/swagger
+./oas_generate.sh api/cds_energy_sdh.json openapi-yaml yaml ../slate/source/includes/swagger
 ./swagger_generate.sh api/cds_common.json swagger-yaml yaml ../slate/source/includes/swagger
 ./swagger_generate.sh api/cds_admin.json swagger-yaml yaml ../slate/source/includes/swagger
 ./swagger_generate.sh api/cds_register.json swagger-yaml yaml ../slate/source/includes/swagger

--- a/swagger-gen/publish_markdown.sh
+++ b/swagger-gen/publish_markdown.sh
@@ -4,6 +4,7 @@ echo "*** Publishing Markdown ***"
 
 cp cds_banking.md ../slate/source/includes/cds_banking.md
 cp cds_energy.md ../slate/source/includes/cds_energy.md
+cp cds_energy_sdh.md ../slate/source/includes/cds_energy_sdh.md
 cp cds_common.md ../slate/source/includes/cds_common.md
 cp cds_admin.md ../slate/source/includes/cds_admin.md
 cp cds_register.md ../slate/source/includes/cds_register.md

--- a/swagger-gen/widdershins-cdr/cdr_widdershins.json
+++ b/swagger-gen/widdershins-cdr/cdr_widdershins.json
@@ -10,6 +10,10 @@
       "tags": ["Energy"]
     },
     {
+      "title": "Energy Secondary Data Holder APIs",
+      "tags": ["Energy-SDH"]
+    },
+    {
       "title": "Common APIs",
       "tags": ["Common"]
     },


### PR DESCRIPTION
Added changes to include Energy Secondary Data Holder OAS in standards with the below checklist

- Include following endpoints:
  - Get  Service Points: Obtain high level details for a list of service points
  - Get  Service Point Detail: Obtain the detail for a specific service point
  - Get  Usage For Service Point: Obtain a list of electricity usage data from a   particular service point
  - Get  Usage For Specific Service Points: Obtain the electricity usage data for a   specific set of service points
  - Get DER For Service Point: Obtain a list   of DER data for a particular service point
  - Get DER  For Specific Service Points: Obtain DER data for a specific set of service points
- Secondary Base Path - GET <base>/secondary/energy/electricity/servicepoints
- Remove x-fapi-auth-date header
- Remove x-fapi-customer-ip-address header
- Remove x-cds-client-headers header
- Add x-cds-arrangement header
- Update description of all occurrence of  servicePointId to reflect it will contain NMI
- Change Get Service Points from GET to   POST




























































