### PR TITLE
Standards Maintenance Issue #524

### DIFF
--- a/slate/source/includes/_energy_apis.md.erb
+++ b/slate/source/includes/_energy_apis.md.erb
@@ -10,4 +10,13 @@ This specification defines the APIs for Data Holders exposing Energy endpoints.
 <tr><td><a href='./includes/swagger/cds_energy.yaml'>Energy OpenAPI Specification (YAML)</a></td></tr>
 </table>
 
+```diff
+Updated description of below fields in `EnergyDerRecord.acConnections`: 
+• `inverterDeviceCapacity`
+• `derDevices.nominalRatedCapacity`
+• `derDevices.nominalStorageCapacity`
+to include
++ Default is 0 if value not known
+```
+
 <%= partial "includes/cds_energy.md" %>

--- a/slate/source/includes/_energy_apis_sdh.md.erb
+++ b/slate/source/includes/_energy_apis_sdh.md.erb
@@ -9,5 +9,13 @@ This specification defines the APIs for Data Holders exposing Energy Secondary D
 <tr><td><a href='./includes/swagger/cds_energy_sdh.yaml'>Energy Secondary Data Holder OpenAPI Specification (YAML)</a></td></tr>
 </table>
 
+```diff
+Updated description of below fields in `EnergyDerRecord.acConnections`: 
+• `inverterDeviceCapacity`
+• `derDevices.nominalRatedCapacity`
+• `derDevices.nominalStorageCapacity`
+to include
++ Default is 0 if value not known
+```
 
 <%= partial "includes/cds_energy_sdh.md" %>

--- a/slate/source/includes/releasenotes/releasenotes.1.20.0.html.md
+++ b/slate/source/includes/releasenotes/releasenotes.1.20.0.html.md
@@ -20,6 +20,7 @@ This release addresses the following minor defects raised on [Standards Staging]
 
 This release addresses the following change requests raised on [Standards Maintenance](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues):
 
+- [Standards Maintenance Issue 524: EnergyDerRecord - mandatory values not available in AEMO's DER register](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/524)
 
 ### Decision Proposals
 
@@ -45,7 +46,7 @@ This release addresses the following Decision Proposals published on [Standards]
 
 |Change|Description|Link|
 |------|-----------|----|
-| | | |
+| Energy schema | [**Standards Maintenance #524**](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/524): Updated description of `inverterDeviceCapacity`, `derDevices.nominalRatedCapacity` and `derDevices.nominalStorageCapacity` fields in `EnergyDerRecord.acConnections` noting 0 as the default when value not known | [Energy Schema](../../#energy-apis) |
 
 
 ## Information Security Profile

--- a/swagger-gen/api/cds_energy.json
+++ b/swagger-gen/api/cds_energy.json
@@ -2436,7 +2436,7 @@
 									]
 								},
 								"inverterDeviceCapacity": {
-									"description": "The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER",
+									"description": "The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER. Default is 0 if value not known",
 									"type": "number"
 								},
 								"derDevices": {
@@ -2496,11 +2496,11 @@
 												"type": "string"
 											},
 											"nominalRatedCapacity": {
-												"description": "Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group",
+												"description": "Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group. Default is 0 if value not known",
 												"type": "number"
 											},
 											"nominalStorageCapacity": {
-												"description": "Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”",
+												"description": "Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”. Default is 0 if value not known",
 												"type": "number"
 											}
 										}

--- a/swagger-gen/api/cds_energy_sdh.json
+++ b/swagger-gen/api/cds_energy_sdh.json
@@ -872,7 +872,7 @@
 									]
 								},
 								"inverterDeviceCapacity": {
-									"description": "The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER",
+									"description": "The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER. Default is 0 if value not known",
 									"type": "number"
 								},
 								"derDevices": {
@@ -932,11 +932,11 @@
 												"type": "string"
 											},
 											"nominalRatedCapacity": {
-												"description": "Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group",
+												"description": "Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group. Default is 0 if value not known",
 												"type": "number"
 											},
 											"nominalStorageCapacity": {
-												"description": "Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”",
+												"description": "Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”. Default is 0 if value not known",
 												"type": "number"
 											}
 										}


### PR DESCRIPTION
Updated description of following fields in EnergyDerRecord.acConnections noting 0 as default when value not known:
• `inverterDeviceCapacity`
• `derDevices.nominalRatedCapacity`
• `derDevices.nominalStorageCapacity`