### PR TITLE
Issue 245 & 152 - Meta objects for energy APIs

### DIFF
--- a/docs/includes/cds_energy
+++ b/docs/includes/cds_energy
@@ -2314,7 +2314,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -3185,7 +3185,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -5315,7 +5315,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -6229,7 +6229,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -7252,7 +7252,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -8540,7 +8540,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -9029,7 +9029,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -9105,7 +9105,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -9168,7 +9168,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -9288,7 +9288,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>

--- a/docs/includes/endpoint-version-schedule/index.html
+++ b/docs/includes/endpoint-version-schedule/index.html
@@ -273,61 +273,6 @@
 </thead><tbody>
 <tr>
 <td style="text-align: left"><strong>Legacy FDO</strong></td>
-<td style="text-align: center">01/07/2021</td>
-<td style="text-align: center">1</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Legacy FDO</strong></td>
-<td style="text-align: center">31/07/2021</td>
-<td style="text-align: center">1</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Legacy FDO</strong></td>
-<td style="text-align: center">31/10/2021</td>
-<td style="text-align: center">1</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Legacy FDO</strong></td>
-<td style="text-align: center">01/11/2021</td>
-<td style="text-align: center">2</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Legacy FDO</strong></td>
-<td style="text-align: center">01/02/2022</td>
-<td style="text-align: center">2</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Y22 #1</strong></td>
-<td style="text-align: center">31/03/2022</td>
-<td style="text-align: center">1</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Legacy FDO</strong></td>
-<td style="text-align: center">01/07/2022</td>
-<td style="text-align: center">2</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Y22 #2</strong></td>
-<td style="text-align: center">04/07/2022</td>
-<td style="text-align: center">1</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Legacy FDO</strong></td>
-<td style="text-align: center">31/07/2022</td>
-<td style="text-align: center">4</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Legacy FDO</strong></td>
-<td style="text-align: center">30/07/2022</td>
-<td style="text-align: center">6</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Y22 #3</strong></td>
-<td style="text-align: center">31/08/2022</td>
-<td style="text-align: center">2</td>
-</tr>
-<tr>
-<td style="text-align: left"><strong>Legacy FDO</strong></td>
 <td style="text-align: center">16/09/2022</td>
 <td style="text-align: center">1</td>
 </tr>
@@ -337,9 +282,14 @@
 <td style="text-align: center">1</td>
 </tr>
 <tr>
+<td style="text-align: left"><strong>Legacy FDO</strong></td>
+<td style="text-align: center">01/11/2022</td>
+<td style="text-align: center">1</td>
+</tr>
+<tr>
 <td style="text-align: left"><strong>Y22 #4</strong></td>
 <td style="text-align: center">15/11/2022</td>
-<td style="text-align: center">1</td>
+<td style="text-align: center">3</td>
 </tr>
 <tr>
 <td style="text-align: left"><strong>Legacy FDO</strong></td>
@@ -359,17 +309,17 @@
 <tr>
 <td style="text-align: left"><strong>Y23 #1</strong></td>
 <td style="text-align: center">14/04/2023</td>
-<td style="text-align: center">1</td>
+<td style="text-align: center">3</td>
 </tr>
 <tr>
 <td style="text-align: left"><strong>Y23 #2</strong></td>
-<td style="text-align: center">08/05/2023</td>
-<td style="text-align: center">0</td>
+<td style="text-align: center">15/05/2023</td>
+<td style="text-align: center">1</td>
 </tr>
 <tr>
 <td style="text-align: left"><strong>Y23 #3</strong></td>
 <td style="text-align: center">10/07/2023</td>
-<td style="text-align: center">1</td>
+<td style="text-align: center">3</td>
 </tr>
 <tr>
 <td style="text-align: left"><strong>Y23 #4</strong></td>
@@ -384,7 +334,7 @@
 <tr>
 <td style="text-align: left"><strong>Y24 #1</strong></td>
 <td style="text-align: center">11/03/2024</td>
-<td style="text-align: center">0</td>
+<td style="text-align: center">2</td>
 </tr>
 <tr>
 <td style="text-align: left"><strong>Y24 #2</strong></td>
@@ -808,7 +758,7 @@
 <td>2022-11-15</td>
 <td>2023-04-14</td>
 <td>2021-10-29, V1.14.0</td>
-<td>TBC, V1.19.0</td>
+<td>2022-09-13, V1.19.0</td>
 </tr>
 <tr>
 <td>Energy APIs</td>
@@ -818,7 +768,7 @@
 <td>V2</td>
 <td>2023-04-14</td>
 <td>N/A</td>
-<td>TBC, V1.19.0</td>
+<td>2022-09-13, V1.19.0</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -830,7 +780,7 @@
 <td>2022-11-15</td>
 <td>2023-04-14</td>
 <td>2021-10-29, V1.14.0</td>
-<td>TBC, V1.19.0</td>
+<td>2022-09-13, V1.19.0</td>
 </tr>
 <tr>
 <td>Energy APIs</td>
@@ -838,9 +788,9 @@
 <td><code>/energy/accounts/{accountId}</code></td>
 <td><span class="method get">GET</span></td>
 <td>V2</td>
-<td>2022-04-14</td>
+<td>2023-04-14</td>
 <td>N/A</td>
-<td>TBC, V1.19.0</td>
+<td>2022-09-13, V1.19.0</td>
 <td>N/A</td>
 </tr>
 <tr>

--- a/docs/includes/releasenotes/releasenotes.1.22.1.html
+++ b/docs/includes/releasenotes/releasenotes.1.22.1.html
@@ -251,16 +251,43 @@
 <p>This release addresses the following minor defects raised on <a href="https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues">Standards Staging</a>:</p>
 
 <ul>
-<li>XXXX</li>
+<li>Issue <a href="https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/257">257</a>: Notice for the Binding Data Standard</li>
+<li>Issue <a href="https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/255">255</a>: Maintenance of obligation date tables</li>
+<li>Issue <a href="https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/254">254</a>: Get Energy Account Detail V2 - Fix binding date</li>
+<li>Issue <a href="https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/254">245</a>: Get Energy APIs: meta object should not be mandatory</li>
+<li>Issue <a href="https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/152">152</a>: Get Meta objects to be optional in energy requests</li>
 </ul>
 <h3 id='decision-proposals'>Decision Proposals</h3>
-<p>This release addresses the following Decision Proposals published on <a href="https://github.com/ConsumerDataStandardsAustralia/standards/issues">Standards</a>:</p>
-
-<ul>
-<li>XXXX</li>
-</ul>
+<p>This release is a patch release and does not include any changes arising from a decision of the Chair</p>
 <h2 id='introduction'>Introduction</h2>
-<p>No changes</p>
+<table><thead>
+<tr>
+<th>Change</th>
+<th>Description</th>
+<th>Link</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>Binding Statement</td>
+<td>Added binding statement to the Introduction section</td>
+<td><a href="../../#introduction">Introduction</a></td>
+</tr>
+<tr>
+<td>Align Obligation Dates</td>
+<td>Corrections to the future dated obligations table</td>
+<td><a href="../../#future-dated-obligations">FDOs</a></td>
+</tr>
+<tr>
+<td>Align Obligation Dates</td>
+<td>Corrections to the obligation dates table</td>
+<td><a href="../endpoint-version-schedule/#obligation-dates-schedule">Obligations Table</a></td>
+</tr>
+<tr>
+<td>Fix Binding Date</td>
+<td>Correct the binding date for Get Energy Account Detail V2 in the end point schedule</td>
+<td><a href="../endpoint-version-schedule/#endpoint-version-schedule">FDOs</a></td>
+</tr>
+</tbody></table>
 <h2 id='high-level-standards'>High Level Standards</h2>
 <p>No changes</p>
 <h2 id='api-end-points'>API End Points</h2>
@@ -272,9 +299,9 @@
 </tr>
 </thead><tbody>
 <tr>
-<td>XXXX</td>
-<td>XXXX</td>
-<td>XXXX</td>
+<td>Meta Objects Optional</td>
+<td>Made the meta object in requests and non-list responses optional for energy APIs to align with decisions</td>
+<td><a href="../../#energy-apis">Energy APIs</a></td>
 </tr>
 </tbody></table>
 <h2 id='information-security-profile'>Information Security Profile</h2>

--- a/docs/includes/swagger/cds_energy.json
+++ b/docs/includes/swagger/cds_energy.json
@@ -4737,7 +4737,7 @@
                   "$ref" : "#/components/schemas/Meta"
                 }
               },
-              "required" : [ "data", "meta" ],
+              "required" : [ "data" ],
               "type" : "object"
             }
           }
@@ -4767,7 +4767,7 @@
                   "$ref" : "#/components/schemas/Meta"
                 }
               },
-              "required" : [ "data", "meta" ],
+              "required" : [ "data" ],
               "type" : "object"
             }
           }
@@ -5285,7 +5285,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyAccountListResponseV2" : {
@@ -5315,7 +5315,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyPaymentScheduleResponse" : {
@@ -5330,7 +5330,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyConcessionsResponse" : {
@@ -5345,7 +5345,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyBalanceListResponse" : {
@@ -5375,7 +5375,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyInvoiceListResponse" : {

--- a/docs/includes/swagger/cds_energy.yaml
+++ b/docs/includes/swagger/cds_energy.yaml
@@ -4727,7 +4727,6 @@ components:
                 $ref: '#/components/schemas/Meta'
             required:
             - data
-            - meta
             type: object
       description: Request payload containing list of specific Service Points to obtain
         data for
@@ -4751,7 +4750,6 @@ components:
                 $ref: '#/components/schemas/Meta'
             required:
             - data
-            - meta
             type: object
       description: Request payload containing list of specific Accounts to obtain
         data for
@@ -5712,7 +5710,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyAccountListResponseV2:
       example:
@@ -5756,7 +5753,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyPaymentScheduleResponse:
       example:
@@ -5817,7 +5813,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyConcessionsResponse:
       example:
@@ -5860,7 +5855,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyBalanceListResponse:
       example:
@@ -5908,7 +5902,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyInvoiceListResponse:
       example:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1776,6 +1776,11 @@ Additional note for v1.22.0: For this version only the delta statements from v1.
 <li>where the standards are specified as binding standards as required by the Consumer Data Right rules for the purposes of s56FA of the legislation, they apply as under contract between a data holder and an accredited data recipient.  The legal effect of binding standards as between data holders and accredited data recipients is fully set out in s56FD and s56FE of the legislation.</li>
 </ul>
 
+<pre class="highlight diff tab-diff"><code><span class="gi">+ Added binding statement in response to legal advice
+</span></code></pre>
+
+<p>Some of these standards will be binding data standards under the Competition and Consumer (Consumer Data Right) Data Standards (No. 1) 2023. See that instrument <a href="https://consumerdatastandards.gov.au/sites/consumerdatastandards.gov.au/files/2023-02/Competition%20and%20Consumer%20%28Consumer%20Data%20Right%29%20Data%20Standards%20%28No.%201%29%202023%20executed.pdf">here</a>. In summary, provisions of these standards (as they exist from time to time) that impose obligations or prohibitions on CDR entities are binding data standards. Provisions included in these standards merely by way of guidance are not binding data standards.</p>
+
 <h2 id='version'>Version</h2>
 
 <p>These standards represent version 1.22.1 of the high level standards.  See the <a href="#versioning">versioning section</a> for more information on how versions are managed in the standard.</p>
@@ -1790,6 +1795,13 @@ Additional note for v1.22.0: For this version only the delta statements from v1.
 
 <p>The table below highlights these areas of the standards.</p>
 
+<pre class="highlight diff tab-diff"><code>Removed obligations more than six months in the past
+
+Reordered FDO entries by applicable date
+
+Corrected some typos
+</code></pre>
+
 <table><thead>
 <tr>
 <th>Section</th>
@@ -1797,96 +1809,6 @@ Additional note for v1.22.0: For this version only the delta statements from v1.
 <th>Applicable Date</th>
 </tr>
 </thead><tbody>
-<tr>
-<td><a href="#error-codes">Standard Error Codes</a></td>
-<td>Data Recipients and Data Holders <strong>MAY</strong> implement the standard error codes from July 1st 2021</td>
-<td>July 1st 2021</td>
-</tr>
-<tr>
-<td><a href="#get-metrics">Get Metrics V2</a></td>
-<td>Version 2 of this end point <strong>MUST</strong> be made available by affected data holders by the end of July 2021</td>
-<td>July 31st 2021</td>
-</tr>
-<tr>
-<td><a href="#get-metrics">Get Metrics V1</a></td>
-<td>Data holders <strong>MAY</strong> obsolete version 1 of this end point from October 31st 2021. Data Holders who go live with consumer data sharing from July 1st 2021 <strong>MAY</strong> go live with only Get Metrics v2 support. The CDR Register <strong>MUST</strong> upgrade their implementation to use version 2 by this time</td>
-<td>October 31st 2021</td>
-</tr>
-<tr>
-<td><a href="#amending-authorisation-standards">Amending Consent</a></td>
-<td>Data Holders <strong>MUST</strong> implement the following standards from November 1st 2021 when a CDR consumer is invited to amend a current authorisation as per rule 4.22A and the ADR has supplied a <code>cdr_arrangement_id</code></td>
-<td>November 1st 2021</td>
-</tr>
-<tr>
-<td><a href="#authorisation-standards">CX Standards: Unavailable Accounts</a></td>
-<td>Data Holders <strong>MAY</strong> implement the following data standards effective from 1 November 2021:<ul><li><strong>Unavailable Accounts:</strong> No accounts can be shown</li><li><strong>Unavailable Accounts:</strong> Authorisation not permitted</li><li><strong>Unavailable Accounts:</strong> Request sharing rights</li></ul></td>
-<td>November 1st 2021</td>
-</tr>
-<tr>
-<td><a href="#withdrawal-standards">CX Standards: Withdrawals</a></td>
-<td>Data Holders <strong>MUST</strong> implement the following data standards effective from 1 February 2022:<ul><li><strong>Withdrawal:</strong> Secondary User Instruction</li></ul></td>
-<td>February 1st 2022</td>
-</tr>
-<tr>
-<td><a href="#error-codes">Standard Error Codes</a></td>
-<td>Data Recipients and Data Holders <strong>MUST</strong> implement the standard error codes from February 1st 2022</td>
-<td>February 1st 2022</td>
-</tr>
-<tr>
-<td><a href="#cdr-arrangement-revocation-end-point">Data Recipient CDR Arrangement Endpoint</a></td>
-<td>From March 31st 2022, Data Recipients <strong>MUST</strong> support &quot;CDR Arrangement JWT&quot; method and &quot;CDR Arrangement Form Parameter&quot; method. <br/>Data Recipients <strong>SHOULD</strong> support the &quot;CDR Arrangement JWT&quot; method before March 31st 2022</td>
-<td>March 31st 2022</td>
-</tr>
-<tr>
-<td><a href="#profile-scope-and-standard-claims-common">Profile Scope Data Language</a></td>
-<td>For new and amended consents and authorisations only, CDR participants <strong>SHOULD</strong> comply with the following standards from 1 February 2022, but <strong>MUST</strong> comply by 1 July 2022:<ul><li>Technical Standards: Revised Claims</li><li>CX Standards: Profile Scope - Data Language Standards</li></ul><strong>Note:</strong> These standards changes <strong>do not</strong> apply to existing consents and authorisations unless they are amended on or following the compliance dates.</td>
-<td>July 1st 2022</td>
-</tr>
-<tr>
-<td><a href="#consumer-experience">CX Standards: Joint Accounts</a></td>
-<td>Data holders <strong>MUST</strong> implement the following data standards from 1 July 2022:<ul><li>Notifications: Alternative notification schedules for joint accounts</li><li>Notifications: Joint account alerts</li><li>Authorisation: Pending status</li><li>Withdrawal: Joint accounts</li></ul></td>
-<td>July 1st 2022</td>
-</tr>
-<tr>
-<td><a href="#security-profile">Information Security profile</a></td>
-<td>FAPI 1.0 adoption is introduced across three phases.<br/><strong>Phase 1: Voluntary FAPI 1.0 support &amp; hygiene enhancements</strong> includes, amongst other changes:<ul><li>Enforces requirements for authorisation code, token and request object use</li><li>Data Holders <strong>MAY</strong> support of FAPI 1.0 Final</li><li>Data Holders <strong>MAY</strong> support of Authorization Code Flow (including <strong><a href="#nref-PKCE">[PKCE]</a></strong> and <strong><a href="#nref-JARM">[JARM]</a></strong>) in conjunction with Hybrid Flow</li></ul></td>
-<td>July 4th 2022</td>
-</tr>
-<tr>
-<td><a href="#get-payee-detail">Get Payee Detail V2</a></td>
-<td>Version 2 of this end point <strong>MUST</strong> be made available by affected data holders by July 31st 2022</td>
-<td>July 31st 2022</td>
-</tr>
-<tr>
-<td><a href="#cdr-arrangement-revocation-end-point">Data Recipient CDR Arrangement Endpoint</a></td>
-<td>From July 31st 2022, Data Holders <strong>MUST</strong> revoke consent using &quot;CDR Arrangement JWT&quot; method. <br/>Data Holders <strong>SHOULD</strong> use the &quot;CDR Arrangement JWT&quot; method from March 31st 2022</td>
-<td>July 31st 2022</td>
-</tr>
-<tr>
-<td><a href="#get-payees">Get Payees V2</a></td>
-<td>Version 2 of this end point <strong>MUST</strong> be made available by affected data holders by July 31st 2022</td>
-<td>July 31st 2022</td>
-</tr>
-<tr>
-<td><a href="#self-signed-jwt-client-authentication">Self-Signed JWT Client Authentication</a></td>
-<td>Until July 31st 2022, Data Recipients <strong>MUST</strong> accept the <a href="#uri-resource-path">Resource Path</a> for the endpoint and the <code>&lt;RecipientBaseURI&gt;</code> as a valid audience value. From July 31st 2022, Data Holders <strong>MUST</strong> use an audience value matching the Resource Path for the endpoint and the Data Recipient <strong>MUST</strong> verify the audience matches the Resource Path for the endpoint.</td>
-<td>July 31st 2022</td>
-</tr>
-<tr>
-<td><a href="#get-payees">Get Payees V1</a></td>
-<td>Data holders <strong>MAY</strong> obsolete version 1 of this end point from August 31st 2022.  Data recipients <strong>MUST</strong> upgrade their implementations to use version 2 by this time</td>
-<td>August 31st 2022</td>
-</tr>
-<tr>
-<td><a href="#get-payee-detail">Get Payee Detail V1</a></td>
-<td>Data holders <strong>MAY</strong> obsolete version 1 of this end point from August 31st 2022.  Data recipients <strong>MUST</strong> upgrade their implementations to use version 2 by this time</td>
-<td>August 31st 2022</td>
-</tr>
-<tr>
-<td><a href="#security-profile">Information Security profile</a></td>
-<td>FAPI 1.0 adoption is introduced across three phases.<br/><strong>Phase 2: FAPI 1.0 Final (Baseline &amp; Advanced)</strong> includes, amongst other changes:<ul><li>Enforces additional requirements for authorisation code, token and request object use</li><li>Enforces PAR-only authorisation request data submission</li><li>Refresh token cycling is not permitted</li><li>Data Holders and Data Recipients <strong>MUST</strong> support FAPI 1.0 Final including <strong><a href="#nref-RFC9126">[RFC9126]</a></strong>, <strong><a href="#nref-RFC7636">[RFC7636]</a></strong> and <strong><a href="#nref-JARM">[JARM]</a></strong></li><li>Data Holders SHOULD support of Authorization Code Flow in conjunction with Hybrid Flow</li></ul></td>
-<td>September 16th 2022</td>
-</tr>
 <tr>
 <td><a href="#get-metrics">Get Metrics V3</a></td>
 <td>Version 3 of this end point <strong>MUST</strong> be made available by affected data holders by October 1st 2022</td>
@@ -1903,9 +1825,14 @@ Additional note for v1.22.0: For this version only the delta statements from v1.
 <td>November 15th 2022</td>
 </tr>
 <tr>
-<td><a href="#registration-validation">Registration Validation</a></td>
-<td>Data Holders <strong>MUST</strong> ignore unsupported authorisation scopes presented in the SSA for the creation and update of client registrations from August 31st 2022</td>
-<td>August 31st 2022</td>
+<td><a href="#get-energy-accounts">Get Energy Accounts V1</a></td>
+<td><ul><li>Data Holders <strong>MAY</strong> go-live on November 15 2022 with v1 of this end point</li><li>Data Holders <strong>MAY</strong> decommission v1 of this end point as soon v2 is supported</li></ul></td>
+<td>November 15th 2022</td>
+</tr>
+<tr>
+<td><a href="#get-energy-account-detail">Get Energy Account Detail V1</a></td>
+<td><ul><li>Data Holders <strong>MAY</strong> go-live on November 15 2022 with v1 of this end point</li><li>Data Holders <strong>MAY</strong> decommission v1 of this end point as soon v2 is supported</li></ul></td>
+<td>November 15th 2022</td>
 </tr>
 <tr>
 <td><a href="#get-account-detail">Get Account Detail V2</a></td>
@@ -1943,21 +1870,6 @@ Additional note for v1.22.0: For this version only the delta statements from v1.
 <td>February 28th 2023</td>
 </tr>
 <tr>
-<td><a href="#get-energy-accounts">Get Energy Accounts V1</a></td>
-<td><ul><li>Data Holders <strong>MAY</strong> go-live on November 15 2022 with v1 of this endopint</li><li>Data Holders <strong>MAY</strong> decommission v1 of this endopint as soon v2 is supported</li></ul></td>
-<td>November 15th 2022</td>
-</tr>
-<tr>
-<td><a href="#get-energy-account-detail">Get Energy Account Detail V1</a></td>
-<td><ul><li>Data Holders <strong>MAY</strong> go-live on November 15 2022 with v1 of this endopint</li><li>Data Holders <strong>MAY</strong> decommission v1 of this endopint as soon v2 is supported</li></ul></td>
-<td>November 15th 2022</td>
-</tr>
-<tr>
-<td><a href="#error-codes">Error Codes: Secondary Data Holder flag</a></td>
-<td><ul><li>Data Holders <strong>MAY</strong> implement the <code>isSecondaryDataHolderError</code> field on <strong>November 15 2022</strong></li><li>Affected Data Holders <strong>MUST</strong> implement <code>isSecondaryDataHolderError</code> field by <strong>May 15 2023</strong></li></ul></td>
-<td>May 15th 2023</td>
-</tr>
-<tr>
 <td><a href="#get-energy-accounts">Get Energy Accounts V2</a></td>
 <td>Data Holder <strong>MUST</strong> implement v2 of this endpoint by <strong>April 14th 2023</strong></td>
 <td>April 14th 2023</td>
@@ -1971,6 +1883,11 @@ Additional note for v1.22.0: For this version only the delta statements from v1.
 <td><a href="#security-profile">Information Security profile</a></td>
 <td>FAPI 1.0 adoption is introduced across four phases.<br/><strong>Phase 3: Support Authorization Code Flow and Hybrid Flow</strong> includes, amongst other changes:<ul><li>Data Holders <strong>MUST</strong> support Authorization Code Flow</li><li>Data Holders <strong>MUST</strong> support Hybrid Flow</li></ul></td>
 <td>April 14th 2023</td>
+</tr>
+<tr>
+<td><a href="#error-codes">Error Codes: Secondary Data Holder flag</a></td>
+<td><ul><li>Data Holders <strong>MAY</strong> implement the <code>isSecondaryDataHolderError</code> field on <strong>November 15 2022</strong></li><li>Affected Data Holders <strong>MUST</strong> implement <code>isSecondaryDataHolderError</code> field by <strong>May 15 2023</strong></li></ul></td>
+<td>May 15th 2023</td>
 </tr>
 <tr>
 <td><a href="#security-profile">Information Security profile</a></td>
@@ -2051,8 +1968,15 @@ Additional note for v1.22.0: For this version only the delta statements from v1.
 
 <p>The actual release dates for the Register APIs are expected to occur prior to these dates and are not defined by the Standards.</p>
 
-<h2 id='endpoint-version-schedule'>Endpoint Version Schedule</h2>
+<h2 id='endpoint-version-schedule'>Endpoint Version Schedule</h2><pre class="highlight diff tab-diff"><code>Updated the obligation dates schedule to have correct
+numbers for each date
 
+Removed entries in the obligation dates schedule older
+than six months
+
+Corrected the year of the obligation date for Get
+Energy Account Detail V2
+</code></pre>
 <p>A table-view of all endpoint versioning is available <a href='includes/endpoint-version-schedule/'>here</a>.</p>
 
 <h2 id='normative-references'>Normative References</h2>
@@ -25844,7 +25768,15 @@ This operation does not require authentication
 <td>NA</td>
 </tr>
 </tbody></table>
-<h1 id='energy-apis'>Energy APIs</h1>
+<h1 id='energy-apis'>Energy APIs</h1><pre class="highlight diff tab-diff"><code>Correction to make the meta object optional for:
+  Get DER for Service Point
+  Get Energy Account Detail
+  Get Agreed Payment Schedule
+  Get Concessions
+  Get Balance for Energy Account
+
+Correction to make the meta object optional in requests
+</code></pre>
 <p>This specification defines the APIs for Data Holders exposing Energy endpoints.</p>
 
 <table>
@@ -28238,7 +28170,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -29137,7 +29069,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -31337,7 +31269,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -32279,7 +32211,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -33330,7 +33262,7 @@ x-cds-client-headers: string
 <td>» meta</td>
 <td>body</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -34622,7 +34554,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -35111,7 +35043,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -35187,7 +35119,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -35250,7 +35182,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>
@@ -35370,7 +35302,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 <tr>
 <td>meta</td>
 <td><a href="#schemacdr-energy-apimeta">Meta</a></td>
-<td>mandatory</td>
+<td>optional</td>
 <td>none</td>
 </tr>
 </tbody></table>

--- a/slate/source/includes/_energy_apis.md.erb
+++ b/slate/source/includes/_energy_apis.md.erb
@@ -1,6 +1,16 @@
 
 # Energy APIs
 
+```diff
+Correction to make the meta object optional for:
+  Get DER for Service Point
+  Get Energy Account Detail
+  Get Agreed Payment Schedule
+  Get Concessions
+  Get Balance for Energy Account
+
+Correction to make the meta object optional in requests
+```
 
 This specification defines the APIs for Data Holders exposing Energy endpoints.
 

--- a/slate/source/includes/cds_energy.md
+++ b/slate/source/includes/cds_energy.md
@@ -1461,7 +1461,7 @@ Obtain the electricity usage data for a specific set of service points
 |body|body|[servicePointIdList](#schemacdr-energy-apiservicepointidlist)|mandatory|Request payload containing list of specific Service Points to obtain data for|
 |» data|body|object|mandatory|none|
 |»» servicePointIds|body|[string]|mandatory|Array of specific servicePointIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 #### Enumerated Values
 
@@ -1961,7 +1961,7 @@ Obtain DER data for a specific set of service points
 |body|body|[servicePointIdList](#schemacdr-energy-apiservicepointidlist)|mandatory|Request payload containing list of specific Service Points to obtain data for|
 |» data|body|object|mandatory|none|
 |»» servicePointIds|body|[string]|mandatory|Array of specific servicePointIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 > Example responses
 
@@ -3276,7 +3276,7 @@ Obtain the current balance for a specified set of accounts
 |body|body|[accountIdList](#schemacdr-energy-apiaccountidlist)|mandatory|Request payload containing list of specific Accounts to obtain data for|
 |» data|body|object|mandatory|none|
 |»» accountIds|body|[string]|mandatory|Array of specific accountIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 > Example responses
 
@@ -3772,7 +3772,7 @@ Obtain invoices for a specified set of accounts
 |body|body|[accountIdList](#schemacdr-energy-apiaccountidlist)|mandatory|Request payload containing list of specific Accounts to obtain data for|
 |» data|body|object|mandatory|none|
 |»» accountIds|body|[string]|mandatory|Array of specific accountIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 > Example responses
 
@@ -4377,7 +4377,7 @@ Obtain billing for a specified set of accounts
 |body|body|[accountIdList](#schemacdr-energy-apiaccountidlist)|mandatory|Request payload containing list of specific Accounts to obtain data for|
 |» data|body|object|mandatory|none|
 |»» accountIds|body|[string]|mandatory|Array of specific accountIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 > Example responses
 
@@ -5468,7 +5468,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |---|---|---|---|
 |data|[EnergyDerRecord](#schemacdr-energy-apienergyderrecord)|mandatory|none|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergyaccountlistresponsev2">EnergyAccountListResponseV2</h3>
 
@@ -5918,7 +5918,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |---|---|---|---|
 |data|[EnergyAccountDetailV2](#schemacdr-energy-apienergyaccountdetailv2)|mandatory|none|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergypaymentscheduleresponse">EnergyPaymentScheduleResponse</h3>
 
@@ -5972,7 +5972,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |data|object|mandatory|none|
 |» paymentSchedules|[[EnergyPaymentSchedule](#schemacdr-energy-apienergypaymentschedule)]|mandatory|Array may be empty if no payment schedule exist|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergyconcessionsresponse">EnergyConcessionsResponse</h3>
 
@@ -6013,7 +6013,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |data|object|mandatory|none|
 |» concessions|[[EnergyConcession](#schemacdr-energy-apienergyconcession)]|mandatory|Array may be empty if no concessions exist|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergybalancelistresponse">EnergyBalanceListResponse</h3>
 
@@ -6079,7 +6079,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |data|object|mandatory|none|
 |» balance|[AmountString](#common-field-types)|mandatory|The current balance of the account.  A positive value indicates that amount is owing to be paid.  A negative value indicates that the account is in credit|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergyinvoicelistresponse">EnergyInvoiceListResponse</h3>
 

--- a/slate/source/includes/releasenotes/releasenotes.1.22.1.html.md
+++ b/slate/source/includes/releasenotes/releasenotes.1.22.1.html.md
@@ -20,6 +20,8 @@ This release addresses the following minor defects raised on [Standards Staging]
 - Issue [257](https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/257): Notice for the Binding Data Standard
 - Issue [255](https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/255): Maintenance of obligation date tables
 - Issue [254](https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/254): Get Energy Account Detail V2 - Fix binding date
+- Issue [245](https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/254): Get Energy APIs: meta object should not be mandatory
+- Issue [152](https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/152): Get Meta objects to be optional in energy requests
 
 
 ### Decision Proposals
@@ -44,7 +46,7 @@ No changes
 
 |Change|Description|Link|
 |------|-----------|----|
-| XXXX | XXXX | XXXX |
+| Meta Objects Optional | Made the meta object in requests and non-list responses optional for energy APIs to align with decisions | [Energy APIs](../../#energy-apis) |
 
 
 ## Information Security Profile

--- a/slate/source/includes/swagger/cds_energy.json
+++ b/slate/source/includes/swagger/cds_energy.json
@@ -4737,7 +4737,7 @@
                   "$ref" : "#/components/schemas/Meta"
                 }
               },
-              "required" : [ "data", "meta" ],
+              "required" : [ "data" ],
               "type" : "object"
             }
           }
@@ -4767,7 +4767,7 @@
                   "$ref" : "#/components/schemas/Meta"
                 }
               },
-              "required" : [ "data", "meta" ],
+              "required" : [ "data" ],
               "type" : "object"
             }
           }
@@ -5285,7 +5285,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyAccountListResponseV2" : {
@@ -5315,7 +5315,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyPaymentScheduleResponse" : {
@@ -5330,7 +5330,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyConcessionsResponse" : {
@@ -5345,7 +5345,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyBalanceListResponse" : {
@@ -5375,7 +5375,7 @@
             "$ref" : "#/components/schemas/Meta"
           }
         },
-        "required" : [ "data", "links", "meta" ],
+        "required" : [ "data", "links" ],
         "type" : "object"
       },
       "EnergyInvoiceListResponse" : {

--- a/slate/source/includes/swagger/cds_energy.yaml
+++ b/slate/source/includes/swagger/cds_energy.yaml
@@ -4727,7 +4727,6 @@ components:
                 $ref: '#/components/schemas/Meta'
             required:
             - data
-            - meta
             type: object
       description: Request payload containing list of specific Service Points to obtain
         data for
@@ -4751,7 +4750,6 @@ components:
                 $ref: '#/components/schemas/Meta'
             required:
             - data
-            - meta
             type: object
       description: Request payload containing list of specific Accounts to obtain
         data for
@@ -5712,7 +5710,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyAccountListResponseV2:
       example:
@@ -5756,7 +5753,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyPaymentScheduleResponse:
       example:
@@ -5817,7 +5813,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyConcessionsResponse:
       example:
@@ -5860,7 +5855,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyBalanceListResponse:
       example:
@@ -5908,7 +5902,6 @@ components:
       required:
       - data
       - links
-      - meta
       type: object
     EnergyInvoiceListResponse:
       example:

--- a/swagger-gen/api/cds_energy.json
+++ b/swagger-gen/api/cds_energy.json
@@ -170,8 +170,7 @@
                 "type": "object",
                 "required": [
                     "data",
-                    "links",
-                    "meta"
+                    "links"
                 ],
                 "properties": {
                     "data": {
@@ -220,8 +219,7 @@
                 "type": "object",
                 "required": [
                     "data",
-                    "links",
-                    "meta"
+                    "links"
                 ],
                 "properties": {
                     "data": {
@@ -239,8 +237,7 @@
                 "type": "object",
                 "required": [
                     "data",
-                    "links",
-                    "meta"
+                    "links"
                 ],
                 "properties": {
                     "data": {
@@ -270,8 +267,7 @@
                 "type": "object",
                 "required": [
                     "data",
-                    "links",
-                    "meta"
+                    "links"
                 ],
                 "properties": {
                     "data": {
@@ -347,8 +343,7 @@
                 "type": "object",
                 "required": [
                     "data",
-                    "links",
-                    "meta"
+                    "links"
                 ],
                 "properties": {
                     "data": {
@@ -4194,8 +4189,7 @@
 						"schema": {
 							"type": "object",
 							"required": [
-								"data",
-								"meta"
+								"data"
 							],
 							"properties": {
 								"data": {
@@ -4229,8 +4223,7 @@
 						"schema": {
 							"type": "object",
 							"required": [
-								"data",
-								"meta"
+								"data"
 							],
 							"properties": {
 								"data": {

--- a/swagger-gen/cds_energy.md
+++ b/swagger-gen/cds_energy.md
@@ -1461,7 +1461,7 @@ Obtain the electricity usage data for a specific set of service points
 |body|body|[servicePointIdList](#schemacdr-energy-apiservicepointidlist)|mandatory|Request payload containing list of specific Service Points to obtain data for|
 |» data|body|object|mandatory|none|
 |»» servicePointIds|body|[string]|mandatory|Array of specific servicePointIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 #### Enumerated Values
 
@@ -1961,7 +1961,7 @@ Obtain DER data for a specific set of service points
 |body|body|[servicePointIdList](#schemacdr-energy-apiservicepointidlist)|mandatory|Request payload containing list of specific Service Points to obtain data for|
 |» data|body|object|mandatory|none|
 |»» servicePointIds|body|[string]|mandatory|Array of specific servicePointIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 > Example responses
 
@@ -3276,7 +3276,7 @@ Obtain the current balance for a specified set of accounts
 |body|body|[accountIdList](#schemacdr-energy-apiaccountidlist)|mandatory|Request payload containing list of specific Accounts to obtain data for|
 |» data|body|object|mandatory|none|
 |»» accountIds|body|[string]|mandatory|Array of specific accountIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 > Example responses
 
@@ -3772,7 +3772,7 @@ Obtain invoices for a specified set of accounts
 |body|body|[accountIdList](#schemacdr-energy-apiaccountidlist)|mandatory|Request payload containing list of specific Accounts to obtain data for|
 |» data|body|object|mandatory|none|
 |»» accountIds|body|[string]|mandatory|Array of specific accountIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 > Example responses
 
@@ -4377,7 +4377,7 @@ Obtain billing for a specified set of accounts
 |body|body|[accountIdList](#schemacdr-energy-apiaccountidlist)|mandatory|Request payload containing list of specific Accounts to obtain data for|
 |» data|body|object|mandatory|none|
 |»» accountIds|body|[string]|mandatory|Array of specific accountIds to obtain data for|
-|» meta|body|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|» meta|body|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 > Example responses
 
@@ -5468,7 +5468,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |---|---|---|---|
 |data|[EnergyDerRecord](#schemacdr-energy-apienergyderrecord)|mandatory|none|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergyaccountlistresponsev2">EnergyAccountListResponseV2</h3>
 
@@ -5918,7 +5918,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |---|---|---|---|
 |data|[EnergyAccountDetailV2](#schemacdr-energy-apienergyaccountdetailv2)|mandatory|none|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergypaymentscheduleresponse">EnergyPaymentScheduleResponse</h3>
 
@@ -5972,7 +5972,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |data|object|mandatory|none|
 |» paymentSchedules|[[EnergyPaymentSchedule](#schemacdr-energy-apienergypaymentschedule)]|mandatory|Array may be empty if no payment schedule exist|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergyconcessionsresponse">EnergyConcessionsResponse</h3>
 
@@ -6013,7 +6013,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |data|object|mandatory|none|
 |» concessions|[[EnergyConcession](#schemacdr-energy-apienergyconcession)]|mandatory|Array may be empty if no concessions exist|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergybalancelistresponse">EnergyBalanceListResponse</h3>
 
@@ -6079,7 +6079,7 @@ To perform this operation, you must be authenticated and authorised with the fol
 |data|object|mandatory|none|
 |» balance|[AmountString](#common-field-types)|mandatory|The current balance of the account.  A positive value indicates that amount is owing to be paid.  A negative value indicates that the account is in credit|
 |links|[Links](#schemacdr-energy-apilinks)|mandatory|none|
-|meta|[Meta](#schemacdr-energy-apimeta)|mandatory|none|
+|meta|[Meta](#schemacdr-energy-apimeta)|optional|none|
 
 <h3 class="schema-toc" id="tocSenergyinvoicelistresponse">EnergyInvoiceListResponse</h3>
 


### PR DESCRIPTION
Made the meta object in requests and non-list responses optional for energy APIs to align with decisions

Closes #245, #152