### PR TITLE
Fix typos to clarify documentation

### DIFF
--- a/swagger-gen/api/cds_register.json
+++ b/swagger-gen/api/cds_register.json
@@ -1085,7 +1085,7 @@
           },
           "kid": {
             "type": "string",
-            "description": "The \"kid\" (key ID) parameter is partially used to match a specific key. Note the \"kid\" parameter is not guaranteed unique and additional parameters should be used to progressively to identify a key within a set",
+            "description": "The \"kid\" (key ID) parameter is partially used to match a specific key. Note the \"kid\" parameter is not guaranteed to be unique and additional parameters should be used to progressively identify a key within a set",
             "x-cds-type": "ExternalRef"
           },
           "kty": {


### PR DESCRIPTION
Documentation update from MI17 holistic thread but not included in release 1.29.0.
Addresses: https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/612#issuecomment-1720719607

