### PR TITLE
Removed text referring to historical FDOs

### DIFF
--- a/slate/source/includes/cx_standards/amending_authorisation.md
+++ b/slate/source/includes/cx_standards/amending_authorisation.md
@@ -6,4 +6,3 @@
 |Account Selection|Where account selection applies, Data Holders **MUST** pre-select accounts that were associated with the previous authorisation provided these accounts remain eligible and available to share. Data Holders **MAY** allow these accounts to be amended, and **MAY** provide information regarding the pre-selection of accounts.|
 |Changing Attributes| Data Holders **MUST** indicate where a dataset is being added to an authorisation or a disclosure duration is being amended. Data Holders **MAY** apply this standard to other changing attributes, but this **MUST ONLY** apply where the attribute in the new authorisation differs to that of the previous authorisation. How a changed attributed is signified is at the Data Holder’s discretion.|
 
-<br>Refer also to [Future Dated obligations](#future-dated-obligations)<br>


### PR DESCRIPTION
Documentation update from MI17 holistic thread but not included in release 1.29.0. Addresses: https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/612#issuecomment-1730719461