### PR TITLE
Fix typos to clarify documentation

### DIFF
--- a/slate/source/includes/_register.md.erb
+++ b/slate/source/includes/_register.md.erb
@@ -9,7 +9,9 @@ These endpoints are exposed by the Register and consumed by Data Holders and Dat
   These statuses are provided authoritatively by the Register to allow participants to determine whether a connecting third-party is permitted to perform registration requests or data sharing requests.
 </aside>
 
-
+```diff
+**v1.29.1 Change** Corrected typos in the description of the `kid` field in the 'JWK' schema of the 'Get JWKS' endpoint
+```
 
 <br>
 <table>

--- a/slate/source/includes/releasenotes/releasenotes.1.29.1.html.md
+++ b/slate/source/includes/releasenotes/releasenotes.1.29.1.html.md
@@ -21,7 +21,7 @@ This release addresses the following minor defects raised on [Standards Staging]
 
 This release addresses the following change requests raised on [Standards Maintenance](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues):
 
-- [Maintenance Issue xxx - Description](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/xxx)
+- [Maintenance Issue 612 - Maintenance Iteration 17 Holistic Feedback](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/612)
 
 ### Decision Proposals
 
@@ -59,6 +59,7 @@ This release addresses the following Decision Proposals published on [Standards]
 
 |Change|Description|Link|
 |------|-----------|----|
+|Corrected typos|**[Maintenance Issue 612 - Maintenance Iteration 17 Holistic Feedback](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/612#issuecomment-1720719607):** Corrected typos in the description of the `kid` field in the 'JWK' schema of the 'Get JWKS' endpoint|[JWK schema](../../#cdr-participant-discovery-api_schemas_tocSjwk)|
 
 ## Consumer Experience
 

--- a/swagger-gen/api/cds_register.json
+++ b/swagger-gen/api/cds_register.json
@@ -1085,7 +1085,7 @@
           },
           "kid": {
             "type": "string",
-            "description": "The \"kid\" (key ID) parameter is partially used to match a specific key. Note the \"kid\" parameter is not guaranteed unique and additional parameters should be used to progressively to identify a key within a set",
+            "description": "The \"kid\" (key ID) parameter is partially used to match a specific key. Note the \"kid\" parameter is not guaranteed to be unique and additional parameters should be used to progressively identify a key within a set",
             "x-cds-type": "ExternalRef"
           },
           "kty": {


### PR DESCRIPTION
Documentation update from MI17 holistic thread but not included in release 1.29.0.

Addresses: https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/612#issuecomment-1720719607