### PR TITLE
Removed text referring to historical FDOs

### DIFF
--- a/slate/source/includes/cx_standards/amending_authorisation.md
+++ b/slate/source/includes/cx_standards/amending_authorisation.md
@@ -1,4 +1,9 @@
 ## Amending Authorisation Standards
+
+```diff
+**v1.29.1 Change** Removed reference to Future Dated Obligations as the obligation dates for the associated requirements have passed
+```
+
 |Area|CX Standard|
 |-------------------|------------------------------|
 |**Authorisation:**<br/>Amending consent | The following standards apply when a Data Holder invites a CDR consumer to amend a current authorisation as per rule 4.22A and the ADR has supplied a *cdr_arrangement_id*:|
@@ -6,4 +11,3 @@
 |Account Selection|Where account selection applies, Data Holders **MUST** pre-select accounts that were associated with the previous authorisation provided these accounts remain eligible and available to share. Data Holders **MAY** allow these accounts to be amended, and **MAY** provide information regarding the pre-selection of accounts.|
 |Changing Attributes| Data Holders **MUST** indicate where a dataset is being added to an authorisation or a disclosure duration is being amended. Data Holders **MAY** apply this standard to other changing attributes, but this **MUST ONLY** apply where the attribute in the new authorisation differs to that of the previous authorisation. How a changed attributed is signified is at the Data Holder’s discretion.|
 
-<br>Refer also to [Future Dated obligations](#future-dated-obligations)<br>

--- a/slate/source/includes/releasenotes/releasenotes.1.29.1.html.md
+++ b/slate/source/includes/releasenotes/releasenotes.1.29.1.html.md
@@ -21,7 +21,7 @@ This release addresses the following minor defects raised on [Standards Staging]
 
 This release addresses the following change requests raised on [Standards Maintenance](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues):
 
-- [Maintenance Issue xxx - Description](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/xxx)
+- [Maintenance Issue 612 - Maintenance Iteration 17 Holistic Feedback](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/612)
 
 ### Decision Proposals
 
@@ -64,6 +64,7 @@ This release addresses the following Decision Proposals published on [Standards]
 
 |Change|Description|Link|
 |------|-----------|----|
+|Removed reference to FDOs|**[Maintenance Issue 612 - Maintenance Iteration 17 Holistic Feedback](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/612#issuecomment-1730719461):** Removed reference to Future Dated Obligations as the obligation dates for the associated requirements have passed|[Amending Authorisation Standards](../../#amending-authorisation-standards)|
 
 ## Non-Functional Requirements
 


### PR DESCRIPTION
Documentation update from MI17 holistic thread which was not included in release 1.29.0. 
Addresses: https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/612#issuecomment-1730719461