### PR TITLE
Maint 671 - Remove deprecated Register scopes and values

### DIFF
--- a/slate/source/includes/_scopes.md.erb
+++ b/slate/source/includes/_scopes.md.erb
@@ -44,11 +44,14 @@ Scope Name | Scope ID |Description
 
 The following scopes are used for administrative interactions. These scopes **MUST** never be included in the same access token as a CDR Data scope.
 
+```diff
+Removed deprecated Register scope detail and updated the description of the Participant Data scope.
+- cdr-register:bank:read
+```
 
 Scope Name | Scope ID |Description
 -----------|----------|-----------
 **Basic Admin Metrics Data** | `admin:metrics.basic:read` | Metrics data accessible ONLY to the CDR Register. If the Data Holder uses Private Key JWT Client Authentication to authenticate the CDR Register, this scope is required.<br><br>Includes access to basic Metrics data.
 **Admin Metadata Update Data** | `admin:metadata:update` | Update notification accessible ONLY to the CDR Register. If the Data Holder uses Private Key JWT Client Authentication to authenticate the CDR Register, this scope is required.<br><br>Includes permission to notify Data Holders of changes to Data Recipient metadata held by the CDR Register.
-**Bank Participant Data** | `cdr-register:bank:read` | This scope would allow Data Recipients and Data Holders access to participant metadata in the banking sector, held by the CDR Register. <br>This scope is valid for the following endpoint versions:<ul><li>Get Data Holder Brands [**V1**](includes/obsolete/get-data-holder-brands-v1.html#get-data-holder-brands-v1).</li><li>Get Software Statement Assertion [**V2**](includes/obsolete/get-software-statement-assertion-v2.html#get-software-statement-assertion-ssa-v2).</li></ul>This scope is replaced by `cdr-register:read` for newer versions of these endpoints.
-**Participant Data** | `cdr-register:read` | This scope would allow Data Recipients and Data Holders access to participant metadata held by the CDR Register. <br> Replaces `cdr-register:bank:read` for the following endpoint versions:<ul><li>Get Data Holder Brands [**V2**](#cdr-register-api_get-data-holder-brands).</li><li>Get Software Statement Assertion [**V3**](#cdr-register-api_get-software-statement-assertion-ssa).</li></ul>
+**Participant Data** | `cdr-register:read` | This scope allows Data Recipients to get a Software Statement Assertion and access to Data Holder metadata held by the CDR Register.
 **Register Client** | `cdr:registration` | This scope would allow a Data Recipient to register or manage a software product client with a Data Holder.

--- a/slate/source/includes/releasenotes/releasenotes.1.35.0.html.md
+++ b/slate/source/includes/releasenotes/releasenotes.1.35.0.html.md
@@ -24,7 +24,7 @@ This release addresses the following minor defects raised on [Standards Staging]
 
 This release addresses the following change requests raised on [Standards Maintenance](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues):
 
-- [Standards Maintenance #XXX - Title](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/XXX)
+- [Standards Maintenance #671 - Remove deprecated Register scope detail](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/671)
 
 
 ### Decision Proposals
@@ -36,9 +36,7 @@ This release addresses the following Decision Proposals published on [Standards]
 ## General Changes
 |Change|Description|Link|
 |------|-----------|----|
-| Change summary | [**Standards Staging #XXX**](https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/XXX): Change detail. | [Standards section](../../#section)
-| Change summary | [**Standards Maintenance #XXX**](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/XXX): Change detail. | [Standards section](../../#section)
-| Change summary | [**Decision Proposal #XXX**](https://github.com/ConsumerDataStandardsAustralia/standards/issues/XXX): Change detail. | [Standards section](../../#section)
+| Remove deprecated Register scope detail | [**Standards Maintenance #671**](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/671): Updated Admin & Registration scope table and Non-Normative Examples for the Register token and openid-configuration endpoints to replace placeholders and deprecated details with current values. | [Admin & Registration](../../#admin-amp-registration)<br>[Security Profile](../../#security-profile)
 
 
 ## Introduction

--- a/slate/source/includes/security/_client_authentication.md
+++ b/slate/source/includes/security/_client_authentication.md
@@ -208,19 +208,33 @@ In addition to the requirements for [Private Key JWT Client Authentication](#pri
 
 ### Data Recipients calling the CDR Register
 
+```diff
+Updated details in the Non-Normative Example for the Register token endpoint
+- Host: cdr.register
++ Host: secure.api.cdr.gov.au
+
+- scope=cdr-register%3Abank%3Aread
++ scope=cdr-register%3Aread
+
+- "aud": "https://cdr.register/idp/connect/token",
++ "aud": "https://secure.api.cdr.gov.au/idp/connect/token",
+
+- "scope": "cdr-register:bank:read openid"
++ "scope": "cdr-register:read openid"
+```
 
 > Non-Normative Example - Data Recipient Software Product requests CDR Register Access Token
 
 ```
 POST /token HTTP/1.1
-Host: cdr.register
+Host: secure.api.cdr.gov.au
 Content-Type: application/x-www-form-urlencoded
 
 grant_type=client_credentials&
-  client_id=<brand id> OR <software product id> &
+  client_id=<brand id> OR <software product id>&
   client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&
   client_assertion=eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEyNDU2In0.ey...&
-  scope=cdr-register%3Abank%3Aread
+  scope=cdr-register%3Aread
 
 ## Decoded client assertion JWT
 {
@@ -232,17 +246,16 @@ grant_type=client_credentials&
   "iss": "<brand id> OR <software product id>",
   "sub": "<brand id> OR <software product id>",
   "exp": 1516239322,
-  "aud": "https://cdr.register/idp/connect/token",
+  "aud": "https://secure.api.cdr.gov.au/idp/connect/token",
   "jti": "37747cd1-c105-4569-9f75-4adf28b73e31"
 }
-
 
 ## Response
 {
   "access_token": "eyJhbGciOiJQUz...",
   "expires_in": 7200,
   "token_type": "Bearer",
-  "scope": "cdr-register:bank:read openid"
+  "scope": "cdr-register:read openid"
 }
 ```
 

--- a/slate/source/includes/security/endpoints/_register.md
+++ b/slate/source/includes/security/endpoints/_register.md
@@ -2,21 +2,42 @@
 
 The CDR Register exposes an OIDC Configuration Endpoint with associated JWKS and token endpoints to facilitate issuance of access tokens to consume the protected Register APIs.
 
+```diff
+Updated details in the Non-Normative Example for the Register openid-configuration endpoint
+- GET /.well-known/openid-configuration HTTP/1.1
++ GET /idp/.well-known/openid-configuration HTTP/1.1
+
+- Host: cdr.register
++ Host: api.cdr.gov.au
+
+- "issuer": "https://cdr.register/idp",
++ "issuer": "https://api.cdr.gov.au/idp",
+
+- "jwks_uri": "https://cdr.register/idp/.well-known/openid-configuration/jwks",
++ "jwks_uri": "https://api.cdr.gov.au/idp/.well-known/openid-configuration/jwks",
+
+- "token_endpoint": "https://cdr.register/idp/connect/token",
++ "token_endpoint": "https://secure.api.cdr.gov.au/idp/connect/token",
+
+- "scopes_supported": ["cdr-register:bank:read"],
++ "scopes_supported": ["cdr-register:read"],
+```
+
 > Retrieve CDR Register OIDC Discovery Endpoint
 
 ```
-GET /.well-known/openid-configuration HTTP/1.1
-Host: cdr.register
+GET /idp/.well-known/openid-configuration HTTP/1.1
+Host: api.cdr.gov.au
 
 ## Response
 {
-  "issuer": "https://cdr.register/idp",
-  "jwks_uri": "https://cdr.register/idp/.well-known/openid-configuration/jwks",
-  "token_endpoint": "https://cdr.register/idp/connect/token",
+  "issuer": "https://api.cdr.gov.au/idp",
+  "jwks_uri": "https://api.cdr.gov.au/idp/.well-known/openid-configuration/jwks",
+  "token_endpoint": "https://secure.api.cdr.gov.au/idp/connect/token",
   "claims_supported": ["sub"],
   "id_token_signing_alg_values_supported": ["PS256"],
   "subject_types_supported": ["public"],
-  "scopes_supported": ["cdr-register:bank:read"],
+  "scopes_supported": ["cdr-register:read"],
   "response_types_supported": ["token"],
   "grant_types_supported": ["client_credentials"],
   "token_endpoint_auth_methods_supported": ["private_key_jwt"],


### PR DESCRIPTION
Addresses: https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/671