### PR TITLE
Maint 656 - Added detail for Banking transaction status enum

### DIFF
--- a/slate/source/includes/_banking_apis.md.erb
+++ b/slate/source/includes/_banking_apis.md.erb
@@ -1,6 +1,10 @@
 # Banking APIs
 
-
+```diff
+Added detail for the Banking Transaction status enum values.
++ PENDING meaning the transaction has affected the availableBalance of the account
++ POSTED meaning it has affected the availableBalance and currentBalance of the account.
+```
 
 This specification defines the APIs for Data Holders exposing Banking endpoints.
 

--- a/slate/source/includes/releasenotes/releasenotes.1.35.0.html.md
+++ b/slate/source/includes/releasenotes/releasenotes.1.35.0.html.md
@@ -24,7 +24,7 @@ This release addresses the following minor defects raised on [Standards Staging]
 
 This release addresses the following change requests raised on [Standards Maintenance](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues):
 
-- [Standards Maintenance #XXX - Title](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/XXX)
+- [Standards Maintenance #656 - A status of POSTED should indicate the final update for a transaction](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/656)
 
 
 ### Decision Proposals
@@ -36,9 +36,6 @@ This release addresses the following Decision Proposals published on [Standards]
 ## General Changes
 |Change|Description|Link|
 |------|-----------|----|
-| Change summary | [**Standards Staging #XXX**](https://github.com/ConsumerDataStandardsAustralia/standards-staging/issues/XXX): Change detail. | [Standards section](../../#section)
-| Change summary | [**Standards Maintenance #XXX**](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/XXX): Change detail. | [Standards section](../../#section)
-| Change summary | [**Decision Proposal #XXX**](https://github.com/ConsumerDataStandardsAustralia/standards/issues/XXX): Change detail. | [Standards section](../../#section)
 
 
 ## Introduction
@@ -54,6 +51,7 @@ This release addresses the following Decision Proposals published on [Standards]
 ## API Endpoints
 |Change|Description|Link|
 |------|-----------|----|
+| Banking transaction status values | [**Standards Maintenance #656**](https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/656): Added detail for the Banking Transaction status enum values. | [Banking APIs](../../#banking-apis)
 
 
 ## Information Security Profile

--- a/swagger-gen/api/cds_banking.json
+++ b/swagger-gen/api/cds_banking.json
@@ -4032,7 +4032,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction.",
+            "description": "Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction.<ul><li>`PENDING` meaning the transaction has affected the _availableBalance_ of the account</li><li>`POSTED` meaning it has affected the _availableBalance_ and _currentBalance_ of the account.</li></ul>",
             "enum": [
               "PENDING",
               "POSTED"

--- a/swagger-gen/api/cds_banking_non_bank_lending.json
+++ b/swagger-gen/api/cds_banking_non_bank_lending.json
@@ -4173,7 +4173,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction.",
+            "description": "Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction.<ul><li>`PENDING` meaning the transaction has affected the _availableBalance_ of the account</li><li>`POSTED` meaning it has affected the _availableBalance_ and _currentBalance_ of the account.</li></ul>",
             "enum": [
               "PENDING",
               "POSTED"


### PR DESCRIPTION
Addresses: https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/656