### PR TITLE
Keep temp folder within the repo and ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .vagrant/
 /docs-dev/
+/temp_cds_swagger_gen/

--- a/swagger-gen/oas_generate.sh
+++ b/swagger-gen/oas_generate.sh
@@ -13,7 +13,7 @@ SWAGGER_CODEGEN=$HOME/swagger-codegen
 OAS_CODEGEN=$HOME/openapi-codegen
 
 #location of generated output
-SWAGGER_CODEGEN_OUTPUT=/tmp/cds_swagger_gen
+SWAGGER_CODEGEN_OUTPUT="$(cd "$(dirname "$0")/.." && pwd)/temp_cds_swagger_gen"
 
 #TODO Command line parse
 # format <filename> <cli_output_format> <ext> <output-dir>


### PR DESCRIPTION
Avoids issues with permissions and cleanup on different platforms, and allows the temp output to be easily reviewed if necessary.